### PR TITLE
DO NOT MERGE!

### DIFF
--- a/AppAmbitSdk/Sources/Analytics/Analytics.swift
+++ b/AppAmbitSdk/Sources/Analytics/Analytics.swift
@@ -1,23 +1,24 @@
 import Foundation
 
 public final class Analytics {
-    
     private nonisolated(unsafe) static var apiService: ApiService?
     private nonisolated(unsafe) static var storageService: StorageService?
     
-    private static let syncQueue = DispatchQueue(label: "com.yourapp.analytics.syncQueue")
+    private static let isolationQueue = DispatchQueue(
+        label: "com.appambit.analytics.isolation",
+        qos: .default,
+        attributes: []
+    )
     
     private init() {}
     
     static func initialize(apiService: ApiService, storageService: StorageService) {
-        syncQueue.sync {
-            self.apiService = apiService
-            self.storageService = storageService
-        }
+        self.apiService = apiService
+        self.storageService = storageService
     }
-
+    
     public static func setUserId(_ userId: String) {
-        syncQueue.sync {
+        isolationQueue.async {
             do {
                 try storageService?.putUserId(userId)
             } catch {
@@ -27,12 +28,40 @@ public final class Analytics {
     }
     
     public static func setEmail(_ email: String) {
-        syncQueue.sync {
+        isolationQueue.async {
             do {
                 try storageService?.putUserEmail(email)
             } catch {
                 debugPrint("Error putting email: \(error)")
             }
         }
-    }    
+    }
+    
+    public static func clearToken() {
+        isolationQueue.async {
+            ServiceContainer.shared.apiService.setToken("")
+        }
+    }
+    
+    public static func trackEvent(eventTitle: String, data: [String: String], createdAt: Date?) {
+        sendOrSaveEvent(eventTitle: eventTitle, data: data, createdAt: createdAt)
+    }
+    
+    private static func sendOrSaveEvent(eventTitle: String, data: [String: String], createdAt: Date?) {
+        let event = Event(
+            name: eventTitle,
+            metadata: data
+        )
+        
+        let endpoint = EventEndpoint(event: event)
+        
+        self.apiService?.executeRequest(endpoint, responseType: EventResponse.self) { result in
+            if result.errorType != .none {
+                debugPrint("Save on datbase event: \(result.message ?? "")")
+                return
+            }
+            
+            debugPrint("Log send")
+        }
+    }
 }

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Api/AppAmbitApiService.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Api/AppAmbitApiService.swift
@@ -1,204 +1,418 @@
 import Foundation
 
-class AppAmbitApiService: ApiService {
-
-    private let workerQueue = DispatchQueue(label: "com.appambit.telemetry.worker", qos: .utility)
+class AppAmbitApiService: ApiService, @unchecked Sendable {
+    
+    private let workerQueue = DispatchQueue(label: "com.appambit.api.worker", qos: .utility)
+    private let workerRenewToken = DispatchQueue(label: "com.appambit.api.renewtoken", attributes: .concurrent)
+    private let tokenQueue = DispatchQueue(label: "com.appambit.token.access", attributes: .concurrent)
+    private let pendingRetryQueue = DispatchQueue(label: "com.appambit.pending.retry.queue", attributes: .concurrent)
+    
+    private var pendingRetryActions: [(ApiErrorType) -> Void] = []
     private let storageService: StorageService
-
+    private var _token: String?
+    private var currentTokenRenewal: ((ApiErrorType) -> Void)?
+    
     private lazy var urlSession: URLSession = {
         let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 30
-        config.timeoutIntervalForResource = 60
+        config.timeoutIntervalForRequest = 10
+        config.timeoutIntervalForResource = 10
         config.waitsForConnectivity = true
         return URLSession(configuration: config)
     }()
-
-    private var _token: String?
-    private let tokenQueue = DispatchQueue(label: "com.appambit.token.access", attributes: .concurrent)
-
+    
     var token: String? {
         get { tokenQueue.sync { _token } }
-        set { tokenQueue.async(flags: .barrier) { self._token = newValue } }
     }
-
+    
     init(storageService: StorageService) {
         self.storageService = storageService
     }
-
+    
     func executeRequest<T: Decodable>(
         _ endpoint: Endpoint,
         responseType: T.Type,
-        completion: @escaping (ApiResult<T>) -> Void
+        completion: @Sendable @escaping (ApiResult<T>) -> Void
     ) {
         workerQueue.async { [completion] in
+            if !ServiceContainer.shared.reachabilityService.isConnected {
+                completion(.fail(.unknown, message: "No internet connection"))
+                return
+            }
+            
             guard let url = URL(string: endpoint.baseUrl + endpoint.url) else {
                 completion(.fail(.unknown, message: "Invalid URL"))
                 return
             }
-
+            
             var request = URLRequest(url: url)
             request.httpMethod = endpoint.method.stringValue
-
+            
             self.configureHeaders(for: &request, endpoint: endpoint)
-
+            
             if let payload = endpoint.payload {
-                if let log = payload as? Log {
-                    let builder = MultipartFormDataBuilder()
-                    builder.append(object: log.toMultipartValue())
-                    let body = builder.finalize()
-                    request.httpBody = body
-                    request.setValue(builder.contentType(), forHTTPHeaderField: "Content-Type")
-
-                    self.printMultipartRequest(request: request, body: body)
-
-                } else if let logBatch = payload as? LogBatch {
-                    let builder = MultipartFormDataBuilder()
-                    builder.append(object: logBatch.toMultipartValue())
-                    let body = builder.finalize()
-                    request.httpBody = body
-                    request.setValue(builder.contentType(), forHTTPHeaderField: "Content-Type")
-
-                    self.printMultipartRequest(request: request, body: body)
-
+                if endpoint.method == .get {
+                    self.handleGETWithQueryParameters(
+                        payload: payload,
+                        request: &request,
+                        responseType: T.self,
+                        completion: completion
+                    )
                 } else {
-                    do {
-                        let payloadDict: [String: Any]
-                        if let convertible = payload as? DictionaryConvertible {
-                            payloadDict = convertible.toDictionary()
-                        } else if let dict = payload as? [String: Any] {
-                            payloadDict = dict
-                        } else {
-                            completion(.fail(.unknown, message: "Payload no convertible"))
-                            return
-                        }
-
-                        let jsonData = try JSONSerialization.data(withJSONObject: payloadDict, options: [.prettyPrinted])
-                        request.httpBody = jsonData
-                        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-
-                        self.printJSONRequest(request: request, jsonData: jsonData)
-
-                    } catch {
-                        completion(.fail(.unknown, message: "Error serializando payload"))
-                        return
+                    if self.isMultipartPayload(payload) {
+                        self.handleMultipartPayload(payload, request: &request)
+                    } else {
+                        self.handleJSONPayload(
+                            payload,
+                            request: &request,
+                            responseType: T.self,
+                            completion: completion
+                        )
                     }
                 }
             }
-
-            self.performNetworkRequest(request: request, responseType: responseType, completion: completion)
+            
+            let isTokenEndpoint = endpoint is TokenEndpoint
+            let skipAuth = endpoint.skipAuthorization
+           
+            self.processResponse(request: request, responseType: responseType) { result in
+                
+                self.workerQueue.async {
+                    switch (result.errorType, result.message) {
+                    case (.unauthorized, _) where !isTokenEndpoint:
+                        self.handleTokenRefresh(
+                            originalRequest: request,
+                            skipAuth: skipAuth,
+                            responseType: responseType,
+                            completion: completion
+                        )
+                    default:
+                        completion(result)
+                    }
+                }
+            }
         }
     }
-
-    func createConsumer(
-        appKey: String,
-        completion: @escaping @Sendable (ApiErrorType) -> Void
-    ) {
-        let completionCopy = completion
+    
+    func getNewToken(completion: @escaping @Sendable (ApiErrorType) -> Void) {
         workerQueue.async { [weak self] in
             guard let self = self else { return }
-
-            let endpoint = ConsumerService.shared.registerConsumer(appKey: appKey)
-
-            self.executeRequest(
-                endpoint,
-                responseType: TokenResponse.self
-            ) { result in
-                if let token = result.data?.token {
-                    self.tokenQueue.async(flags: .barrier) {
-                        self._token = token
-                    }
-                }
+            
+            TokenService.createTokenEndpoint { [weak self] result in
+                guard let self = self else { return }
                 
-                do {
-                    if let consumerId = result.data?.consumerId {
-                        do {
-                            try self.storageService.putConsumerId(String(consumerId))
-                        } catch {
-                            debugPrint("Error saving consumerId: \(error)")
+                switch result {
+                    case .success(let endpoint):
+                        self.fetchToken(using: endpoint, completion: completion)
+                    case .failure:
+                        DispatchQueue.main.async {
+                            completion(.unknown)
                         }
-                    }
-                } catch {
-                    debugPrint("Errror to Save: \(error)")
-                }
-
-                let errorType = result.errorType
-
-                DispatchQueue.main.async {
-                    completionCopy(errorType)
                 }
             }
         }
     }
+    
+    func setToken(_ newToken: String) {
+        tokenQueue.async(flags: .barrier) {
+            self._token = newToken
+        }
+    }
 
+    private func handleTokenRefresh<T: Decodable>(
+        originalRequest: URLRequest?,
+        skipAuth: Bool,
+        responseType: T.Type,
+        completion: @escaping @Sendable (ApiResult<T>) -> Void
+    ) {
+        let retryAction: (ApiErrorType) -> Void = { [weak self] error in
+            guard let self = self else { return }
+            if error == .none, let originalRequest = originalRequest {
+                var newRequest = originalRequest
+                if !skipAuth, let token = self.token {
+                    newRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                }
+                self.processResponse(request: newRequest, responseType: responseType, completion: completion)
+            } else {
+                completion(.fail(error, message: "Fallo en la renovación del token"))
+            }
+        }
+        
+        pendingRetryQueue.async(flags: .barrier) {
+            self.pendingRetryActions.append(retryAction)
+        }
+        
+        workerQueue.async(flags: .barrier) {
+            if self.currentTokenRenewal == nil {
+                self.currentTokenRenewal = { [weak self] error in
+                    guard let self = self else { return }
+                    self.pendingRetryQueue.async(flags: .barrier) {
+                        let actions = self.pendingRetryActions
+                        self.pendingRetryActions.removeAll()
+                        for action in actions {
+                            action(error)
+                        }
+                    }
+                    self.currentTokenRenewal = nil
+                }
+                
+                self.getNewToken { error in
+                    self.workerQueue.async(flags: .barrier) {
+                        self.currentTokenRenewal?(error)
+                    }
+                }
+            }
+        }
+    }
+    
+    private func handleFailedRenewalResult<T>(_ type: T.Type, result: ApiErrorType) -> ApiResult<T> {
+        if result == .networkUnavailable {
+            debugPrint("Cannot retry request: no internet after token renewal")
+            return .fail(.networkUnavailable, message: "No internet after token renewal")
+        }
+        
+        debugPrint("Could not renew token. Cleaning up")
+        clearToken()
+        return .fail(result, message: "Token renewal failed")
+    }
+    
+    private func handleTokenRenewalException<T>(_ type: T.Type, error: Error) -> ApiResult<T> {
+        debugPrint("Error renewing token: \(error)")
+        clearToken()
+        return .fail(.unknown, message: "Token renewal failed")
+    }
+    
+    private func isRenewSuccess(_ error: ApiErrorType) -> Bool {
+        return error == .none
+    }
+    
+    private func isRenewingToken() -> Bool {
+        return currentTokenRenewal != nil
+    }
+    
+    private func handleGETWithQueryParameters<T: Decodable>(
+        payload: Any,
+        request: inout URLRequest,
+        responseType: T.Type,
+        completion: @escaping (ApiResult<T>) -> Void
+    ) {
+        guard var urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false) else {
+            completion(.fail(.unknown, message: "Invalid URL"))
+            return
+        }
+        
+        var queryItems = [URLQueryItem]()
+        
+        if let dictConvertible = payload as? DictionaryConvertible {
+            let dictionary = dictConvertible.toDictionary()
+            queryItems = dictionary.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+        } else if let dictionary = payload as? [String: Any] {
+            queryItems = dictionary.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
+        }
+        
+        urlComponents.queryItems = queryItems.isEmpty ? nil : queryItems
+        
+        guard let urlWithQueryParams = urlComponents.url else {
+            completion(.fail(.unknown, message: "Invalid URL with query parameters"))
+            return
+        }
+        
+        request.url = urlWithQueryParams
+        
+        #if DEBUG
+        debugPrint("HTTP - REQUEST - URL with QueryParams: \(request.url?.absoluteString ?? "N/A")")
+        #endif
+    }
+    
+    /// Determines whether the payload is of the multipart type (Log or LogBatch)
+    private func isMultipartPayload(_ payload: Any) -> Bool {
+        return payload is Log || payload is LogBatch
+    }
+    
+    /// Process multipart payloads (Log or LogBatch)
+    private func handleMultipartPayload(_ payload: Any, request: inout URLRequest) {
+        let builder = MultipartFormDataBuilder()
+        
+        if let log = payload as? Log {
+            builder.append(object: log.toMultipartValue())
+        } else if let logBatch = payload as? LogBatch {
+            builder.append(object: logBatch.toMultipartValue())
+        }
+        
+        let body = builder.finalize()
+        request.httpBody = body
+        request.setValue(builder.contentType(), forHTTPHeaderField: "Content-Type")
+        printMultipartRequest(request: request, body: body)
+    }
+    
+    /// Processes JSON payloads (dictionaries or objects convertible to dictionaries)
+    private func handleJSONPayload<T: Decodable>(
+        _ payload: Any,
+        request: inout URLRequest,
+        responseType: T.Type,
+        completion: @escaping (ApiResult<T>) -> Void
+    ) {
+        do {
+            let payloadDict = try convertToDictionary(payload: payload)
+            let jsonData = try JSONSerialization.data(withJSONObject: payloadDict, options: [.prettyPrinted])
+            
+            request.httpBody = jsonData
+            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+            printJSONRequest(request: request, jsonData: jsonData)
+            
+        } catch let error as ApiErrorType {
+            completion(.fail(error, message: "Payload no convertible"))
+        } catch {
+            completion(.fail(.unknown, message: "Error serializando payload: \(error.localizedDescription)"))
+        }
+    }
+    
+    /// Converts the payload to a dictionary [String: Any]
+    private func convertToDictionary(payload: Any) throws -> [String: Any] {
+        if let convertible = payload as? DictionaryConvertible {
+            return convertible.toDictionary()
+        } else if let dict = payload as? [String: Any] {
+            return dict
+        }
+        throw ApiErrorType.unknown
+    }
+    
+    private func clearToken() {
+        self.tokenQueue.async(flags: .barrier) {
+            self._token = ""
+        }
+    }
+        
+    private func fetchToken(using endpoint: TokenEndpoint, completion: @escaping @Sendable (ApiErrorType) -> Void) {
+        executeRequest(endpoint, responseType: TokenResponse.self) { [weak self] result in
+            guard let self = self else { return }
+            
+            let errorType = result.errorType
+            
+            if let token = result.data?.token {
+                self.tokenQueue.async(flags: .barrier) {
+                    self._token = token
+                    DispatchQueue.main.async {
+                        completion(errorType)
+                    }
+                }
+            } else {
+                DispatchQueue.main.async {
+                    completion(errorType)
+                }
+            }
+        }
+    }
+    
     private func configureHeaders(for request: inout URLRequest, endpoint: Endpoint) {
         if let headers = endpoint.customHeader {
             for (key, value) in headers {
                 request.addValue(value, forHTTPHeaderField: key)
             }
         }
-
+        
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        
+        self.addAuthorizationHeaderIfNeeded(for: &request, endpoint: endpoint)
+    }
+    
+    private func addAuthorizationHeaderIfNeeded(for request: inout URLRequest, endpoint: Endpoint) {
         if !endpoint.skipAuthorization, let token = self.token {
             request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
     }
-
-    private func performNetworkRequest<T: Decodable>(
+    
+    private func processResponse<T: Decodable>(
         request: URLRequest,
         responseType: T.Type,
-        completion: @escaping (ApiResult<T>) -> Void
+        completion: @escaping @Sendable (ApiResult<T>) -> Void
     ) {
         urlSession.dataTask(with: request) { [weak self] data, response, error in
-            self?.workerQueue.async {
-                if let error = error {
-                    self?.handleFailureResponse(error: error, completion: completion)
-                } else if let data = data, let response = response {
-                    self?.handleSuccessResponse(data: data, response: response, responseType: responseType, completion: completion)
-                } else {
-                    self?.handleFailureResponse(error: URLError(.badServerResponse), completion: completion)
+            guard let self = self else { return }
+            
+            self.workerQueue.async {
+                let result = Result<T, Error> { try self.processData(data, response, error) }
+                
+                switch result {
+                case .success(let decoded):
+                    completion(ApiResult.success(decoded))
+                    
+                case .failure(let error as ApiExceptions):
+                    let apiErrorType: ApiErrorType
+                    switch error {
+                    case .unauthorized:
+                        apiErrorType = .unauthorized
+                    case .networkError:
+                        apiErrorType = .networkUnavailable
+                    default:
+                        apiErrorType = .unknown
+                    }
+                    completion(.fail(apiErrorType, message: error.localizedDescription))
+
+                    
+                case .failure(let error):
+                    completion(ApiResult.fail(.unknown, message: error.localizedDescription))
                 }
             }
         }.resume()
     }
-    
-    private func handleSuccessResponse<T: Decodable>(
-        data: Data,
-        response: URLResponse,
-        responseType: T.Type,
-        completion: @escaping (ApiResult<T>) -> Void
-    ) {
-        if let httpResponse = response as? HTTPURLResponse {
-            debugPrint("HTTP RESPONSE - CODE: \(httpResponse.statusCode)")
 
+    private func processData<T: Decodable>(_ data: Data?, _ response: URLResponse?, _ error: Error?) throws -> T {
+        if let error = error {
+            if let urlError = error as? URLError {
+                throw ApiExceptions.networkError(urlError)
+            }
+            throw ApiExceptions.networkError(URLError(.unknown))
+        }
+        
+        guard let data = data, let response = response else {
+            throw URLError(.badServerResponse)
+        }
+        
+        if let httpResponse = response as? HTTPURLResponse {
             switch httpResponse.statusCode {
             case 401:
-                completion(.fail(.unauthorized, message: "Unauthorized"))
-                return
+                throw ApiExceptions.unauthorized
             case 200..<300:
                 break
             default:
-                completion(.fail(.unknown, message: "HTTP status \(httpResponse.statusCode)"))
-                return
+                throw ApiExceptions.httpError(
+                    statusCode: httpResponse.statusCode,
+                    message: "HTTP error"
+                )
             }
         }
-
-        do {
+        
         #if DEBUG
-            if let jsonString = String(data: data, encoding: .utf8) {
-                print("HTTP RESPONSE BODY:\n\(jsonString)")
-            } else {
-                print("HTTP RESPONSE BODY: (could not convert to String)")
-            }
+        if let jsonString = String(data: data, encoding: .utf8) {
+            print("HTTP RESPONSE BODY:\n\(jsonString)")
+        }
         #endif
-            let decoded = try JSONDecoder().decode(T.self, from: data)
-            completion(.success(decoded))
-        } catch {
-            completion(.fail(.unknown, message: "Decoding error: \(error.localizedDescription)"))
+        
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+    
+    private func checkStatusCodeFrom(response: URLResponse) throws {
+        if let httpResponse = response as? HTTPURLResponse {
+            debugPrint("HTTP RESPONSE - CODE: \(httpResponse.statusCode)")
+            
+            guard let httpResponse = response as? HTTPURLResponse else {
+                throw URLError(.badServerResponse)
+            }
+            
+            switch httpResponse.statusCode {
+            case 401:
+                throw ApiExceptions.unauthorized
+            case 200..<300:
+                break
+            default:
+                throw ApiExceptions.httpError(statusCode: httpResponse.statusCode, message: "Unexpected error during request")
+            }
         }
     }
-
+    
     private func handleFailureResponse<T: Decodable>(
         error: Error,
-        completion: @escaping (ApiResult<T>) -> Void
+        completion: @escaping @Sendable (ApiResult<T>) -> Void
     ) {
         if let urlError = error as? URLError, urlError.code == .notConnectedToInternet {
             completion(.fail(.networkUnavailable, message: "No internet connection"))
@@ -206,9 +420,9 @@ class AppAmbitApiService: ApiService {
             completion(.fail(.unknown, message: "Unknown error: \(error.localizedDescription)"))
         }
     }
-
+    
     private func printJSONRequest(request: URLRequest, jsonData: Data) {
-        #if DEBUG
+    #if DEBUG
         debugPrint("HTTP - REQUEST - URL: \(request.url?.absoluteString ?? "N/A")")
         debugPrint("HTTP - REQUEST - Method: \(request.httpMethod ?? "N/A")")
         debugPrint("HTTP - REQUEST - Headers: \(request.allHTTPHeaderFields ?? [:])")
@@ -217,30 +431,21 @@ class AppAmbitApiService: ApiService {
         }else {
             print("HTTP - REQUEST - JSON Body: (could not convert to String)")
         }
-        #endif
+    #endif
     }
-
-    func printMultipartRequest(request: URLRequest, body: Data) {
-        #if DEBUG
+    
+    private func printMultipartRequest(request: URLRequest, body: Data) {
+    #if DEBUG
         debugPrint("HTTP - REQUEST - URL: \(request.url?.absoluteString ?? "N/A")")
         debugPrint("HTTP - REQUEST - Method: \(request.httpMethod ?? "N/A")")
         debugPrint("HTTP - REQUEST - Headers: \(request.allHTTPHeaderFields ?? [:])")
-        let boundary = extractBoundary(from: request) ?? "<boundary unknown>"
+        
         let fullBodyString = String(decoding: body, as: UTF8.self)
-
         print("HTTP - REQUEST - Body full length (\(body.count) bytes):\n\(fullBodyString)")
-
-        let parts = fullBodyString.components(separatedBy: "--\(boundary)")
-        for part in parts.dropFirst() {
-            let lines = part.split(separator: "\r\n", maxSplits: 2, omittingEmptySubsequences: true)
-            if lines.count >= 2 {
-                print("KEY :\n\(lines[0])")
-                print("VALUE:\n\(lines[1])")
-            }
-        }
-        #endif
+        
+    #endif
     }
-
+    
     private func extractBoundary(from request: URLRequest) -> String? {
         guard let contentType = request.value(forHTTPHeaderField: "Content-Type") else { return nil }
         let prefix = "boundary="

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Api/Endpoints/EventEndpoint.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Api/Endpoints/EventEndpoint.swift
@@ -1,0 +1,9 @@
+class EventEndpoint: BaseEndpoint {
+    
+    init(event: Event) {
+        super.init()
+        url = "/events"
+        method = .post
+        payload = event
+    }
+}

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Api/Endpoints/LogEndpoint.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Api/Endpoints/LogEndpoint.swift
@@ -1,6 +1,6 @@
 class LogEndpoint: BaseEndpoint {
     
-    init(log: LogEntity) {
+    init(log: Log) {
         super.init()
         url = "/log"
         method = .post

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Api/Endpoints/RegisterEndpoint.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Api/Endpoints/RegisterEndpoint.swift
@@ -1,9 +1,9 @@
-class RegisterEndpoint: BaseEndpoint {
-    
+class RegisterEndpoint: BaseEndpoint {    
     init(consumer: Consumer) {
         super.init()
         url = "/consumer"
         method = .post
         payload = consumer
+        skipAuthorization = true
     }
 }

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Api/Endpoints/TokenEndpoint.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Api/Endpoints/TokenEndpoint.swift
@@ -1,0 +1,9 @@
+class TokenEndpoint: BaseEndpoint {
+    init(token: ConsumerToken) {
+        super.init()
+        url = "/consumer/token"
+        method = .get
+        payload = token
+        skipAuthorization = true
+    }
+}

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Api/Protocols/ApiService.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Api/Protocols/ApiService.swift
@@ -2,10 +2,12 @@ protocol ApiService {
     func executeRequest<T: Decodable>(
         _ endpoint: Endpoint,
         responseType: T.Type,
-        completion: @escaping (ApiResult<T>) -> Void
+        completion: @Sendable @escaping(ApiResult<T>) -> Void
     )
     
-    func createConsumer(appKey: String, completion: @escaping @Sendable (ApiErrorType) -> Void)
+    func getNewToken(completion: @escaping @Sendable (ApiErrorType) -> Void)
     
-    var token: String? { get set }
+    var token: String? { get }
+    
+    func setToken(_ newToken: String)
 }

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Api/Protocols/Endpoint.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Api/Protocols/Endpoint.swift
@@ -4,5 +4,5 @@ protocol Endpoint {
     var payload: Any? { get }
     var method: HttpMethodApp { get }
     var customHeader: [String: String]? { get set }
-    var skipAuthorization: Bool { get set }
+    var skipAuthorization: Bool { get set }    
 }

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Enums/ApiExceptions.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Enums/ApiExceptions.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum ApiExceptions: Error {
+    case invalidURL
+    case networkError(URLError)
+    case httpError(statusCode: Int, message: String)
+    case decodingError(Error)
+    case unauthorized
+}

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Enums/DatabaseErrorType.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Enums/DatabaseErrorType.swift
@@ -1,0 +1,4 @@
+enum DatabaseErrorType: Error {
+    case missingAppKey
+    case missingConsumerId
+}

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Models/Analytics/Event.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Models/Analytics/Event.swift
@@ -1,29 +1,75 @@
 import Foundation
 
-public struct Event: Codable {
+public class Event: Codable, DictionaryConvertible {
+    // MARK: - Properties
+    
+    /// The name of the event.
+    /// - Remark: This is a required field and should be descriptive.
     public var name: String
-    public private(set) var metadata: [String: String]
-    public var dataJson: String {
+    
+    private var _dataJson: String = "{}"
+    
+    /// Additional metadata associated with the event.
+    /// - Note: Stored as key-value pairs where both keys and values are strings.
+    public var metadata: [String: String] {
         get {
-            guard let data = try? JSONSerialization.data(withJSONObject: metadata, options: []) else {
-                return "{}"
+            if let data = _dataJson.data(using: .utf8),
+               let dict = try? JSONSerialization.jsonObject(with: data) as? [String: String] {
+                return dict
             }
-            return String(data: data, encoding: .utf8) ?? "{}"
+            return [:]
         }
         set {
-            guard
-                let data = newValue.data(using: .utf8),
-                let dict = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: String]
-            else {
-                metadata = [:]
-                return
+            if let jsonData = try? JSONSerialization.data(withJSONObject: newValue, options: []),
+               let jsonString = String(data: jsonData, encoding: .utf8) {
+                _dataJson = jsonString
+            } else {
+                _dataJson = "{}"
             }
-            metadata = dict
+        }
+    }
+    
+    /// Computed property that provides JSON string representation of metadata.
+    public var dataJson: String {
+        get { _dataJson }
+        set {
+            _dataJson = newValue
+            // Update metadata dictionary when dataJson is set
+            _ = metadata
         }
     }
 
-    public init(name: String, metadata: [String: String] = [:]) {
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case metadata
+    }
+
+    public init(
+        name: String,
+        metadata: [String: String] = [:]
+    ) {
         self.name = name
         self.metadata = metadata
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        metadata = try container.decode([String: String].self, forKey: .metadata)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encode(metadata, forKey: .metadata)
+    }
+    
+    // MARK: - DictionaryConvertible
+    
+    public func toDictionary() -> [String: Any] {
+        return [
+            "name": name,
+            "metadata": metadata
+        ]    
     }
 }

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Models/Analytics/EventEntity.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Models/Analytics/EventEntity.swift
@@ -1,69 +1,34 @@
-
 import Foundation
 
-public struct EventEntity: Codable {
+class EventEntity: Event {
     // MARK: - Properties
     
     /// A unique identifier for the event.
-    public let id: UUID
+    public let id: String
     
     /// The date when the event was created.
     /// - Important: Uses UTC format for serialization.
     public let createdAt: Date
     
-    /// The name of the event.
-    /// - Remark: This is a required field and should be descriptive.
-    public var name: String
-    
-    /// Additional metadata associated with the event.
-    /// - Note: Stored as key-value pairs where both keys and values are strings.
-    public var metadata: [String: String]
-    
-    /// Computed property that provides JSON string representation of metadata.
-    /// - Get: Serializes the metadata dictionary to JSON string.
-    ///   Returns "{}" if serialization fails.
-    /// - Set: Attempts to parse the JSON string back into a dictionary.
-    ///   Resets to empty dictionary if parsing fails.
-    public var dataJson: String {
-        get {
-            (try? JSONSerialization.data(withJSONObject: metadata, options: []))
-                .flatMap { String(data: $0, encoding: .utf8) }
-                ?? "{}"
-        }
-        set {
-            if
-                let data = newValue.data(using: .utf8),
-                let dict = try? JSONSerialization.jsonObject(with: data) as? [String: String]
-            {
-                metadata = dict
-            } else {
-                metadata = [:]
-            }
-        }
-    }
-
     private enum CodingKeys: String, CodingKey {
         case id
         case createdAt = "created_at"
-        case name
-        case metadata
     }
 
     public init(
-        id: UUID,
+        id: String,
         createdAt: Date,
         name: String,
         metadata: [String: String] = [:]
     ) {
         self.id = id
         self.createdAt = createdAt
-        self.name = name
-        self.metadata = metadata
+        super.init(name: name, metadata: metadata)
     }
 
-    public init(from decoder: Decoder) throws {
+    public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        id = try container.decode(UUID.self, forKey: .id)
+        id = try container.decode(String.self, forKey: .id)
 
         let dateString = try container.decode(String.self, forKey: .createdAt)
         guard let parsedDate = DateUtils.utcCustomFormatDate(from: dateString) else {
@@ -72,17 +37,15 @@ public struct EventEntity: Codable {
                 debugDescription: "Invalid date format: \(dateString)")
         }
         createdAt = parsedDate
-
-        name = try container.decode(String.self, forKey: .name)
-        metadata = try container.decode([String: String].self, forKey: .metadata)
+        
+        try super.init(from: decoder)
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public override func encode(to encoder: Encoder) throws {
+        try super.encode(to: encoder)
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         let dateString = DateUtils.utcCustomFormatString(from: createdAt)
         try container.encode(dateString, forKey: .createdAt)
-        try container.encode(name, forKey: .name)
-        try container.encode(metadata, forKey: .metadata)
     }
 }

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Models/App/ConsumerToken.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Models/App/ConsumerToken.swift
@@ -1,0 +1,17 @@
+struct ConsumerToken: DictionaryConvertible {
+    var appKey: String
+    var consumerId: String
+    
+    init(appKey: String, consumerId: String) {
+        self.appKey = appKey
+        self.consumerId = consumerId
+    }
+    
+    func toDictionary() -> [String: Any] {
+        return [
+            "app_key": appKey,
+            "consumer_id": consumerId
+        ]
+        
+    }
+}

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Models/Responses/ApiResult.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Models/Responses/ApiResult.swift
@@ -1,4 +1,4 @@
-struct ApiResult<T> {
+struct ApiResult<T>: Sendable where T: Sendable {
     let data: T?
     let errorType: ApiErrorType
     let message: String?

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Models/Responses/EventResponse.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Models/Responses/EventResponse.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct EventResponse: Decodable {
+    let id: Int
+    let name: String
+    let count: Int
+    let consumerId: Int
+    let createdAt: Date
+    let updatedAt: Date
+    let eventData: [EventResponseData]
+    
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case count
+        case consumerId = "consumer_id"
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
+        case eventData = "event_data"
+    }
+}

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Models/Responses/EventResponseData.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Models/Responses/EventResponseData.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct EventResponseData: Codable {
+    let id: String
+    let key: String
+    let value: String
+    let count: Int
+    let eventId: Int
+    
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case key
+        case value
+        case count
+        case eventId = "event_id"
+    }
+}

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Models/Responses/TokenResponse.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Models/Responses/TokenResponse.swift
@@ -1,5 +1,5 @@
 struct TokenResponse: Decodable {
-    let consumerId: Int
+    let consumerId: Int?
     let token: String
 
     private enum CodingKeys: String, CodingKey {

--- a/AppAmbitSdk/Sources/AppAmbitSdk/ServiceContainer.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/ServiceContainer.swift
@@ -4,26 +4,31 @@ final class ServiceContainer {
     let apiService: ApiService
     let appInfoService: AppInfoService
     let storageService: StorageService
+    let reachabilityService: ReachabilityService
 
     private nonisolated(unsafe) static let _instance: ServiceContainer = {
         let dataStore: DataStore
         let storageService: StorageService
-        
+        let reachabilityService: ReachabilityService
+
         do {
             dataStore = try DataStore()
             storageService = try Storable(ds: dataStore)
+            reachabilityService = try ReachabilityService()
         } catch {
-            debugPrint("Error initializing DataStore: \(error)")
-            fatalError("Failed to initialize DataStore")
+            debugPrint("Error initializing DataStore or ReachabilityService: \(error)")
+            fatalError("Failed to initialize ServiceContainer")
         }
 
         return ServiceContainer(
             apiService: AppAmbitApiService(storageService: storageService),
             appInfoService: AppAmbitInfoService(),
-            storageService: storageService
+            storageService: storageService,
+            reachabilityService: reachabilityService
         )
     }()
-        
+    
+    
     private static let accessQueue = DispatchQueue(
         label: "com.appambit.sdk.service.container",
         attributes: .concurrent
@@ -38,10 +43,12 @@ final class ServiceContainer {
     private init(
         apiService: ApiService,
         appInfoService: AppInfoService,
-        storageService: StorageService
+        storageService: StorageService,
+        reachabilityService: ReachabilityService
     ) {
         self.apiService = apiService
         self.appInfoService = appInfoService
         self.storageService = storageService
+        self.reachabilityService = reachabilityService
     }
 }

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Services/ReachabilityService.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Services/ReachabilityService.swift
@@ -1,0 +1,137 @@
+import SystemConfiguration
+import Foundation
+
+final class ReachabilityService: @unchecked Sendable {
+
+    
+    public enum ConnectionStatus {
+        case connected
+        case disconnected
+    }
+    
+    private var reachabilityRef: SCNetworkReachability
+    private let queue = DispatchQueue(label: "com.appambit.simplereachability")
+    private var previousFlags: SCNetworkReachabilityFlags?
+    
+    public var onConnectionChange: (@Sendable (ConnectionStatus) -> Void)?
+
+    
+    private var weakifier: ReachabilityWeakifier?
+    
+    public var isConnected: Bool {
+        queue.sync {
+            guard let flags = currentFlags else { return false }
+            return isNetworkReachable(with: flags)
+        }
+    }
+    
+    private var currentFlags: SCNetworkReachabilityFlags? {
+        var flags = SCNetworkReachabilityFlags()
+        return SCNetworkReachabilityGetFlags(reachabilityRef, &flags) ? flags : nil
+    }
+    
+    // MARK: - Initialization
+    
+    public init() throws {
+        var zeroAddress = sockaddr()
+        zeroAddress.sa_len = UInt8(MemoryLayout<sockaddr>.size)
+        zeroAddress.sa_family = sa_family_t(AF_INET)
+        
+        guard let ref = SCNetworkReachabilityCreateWithAddress(nil, &zeroAddress) else {
+            throw NSError(domain: "SimpleReachability", code: 1, userInfo: [NSLocalizedDescriptionKey: "Failed to create reachability reference"])
+        }
+        
+        self.reachabilityRef = ref
+    }
+    
+    deinit {
+        stopMonitoring()
+    }
+    
+    // MARK: - Public Methods
+    
+    public func initialize() throws {
+        try queue.sync {
+            guard weakifier == nil else { return }
+            
+            let weakifier = ReachabilityWeakifier(reachability: self)
+            self.weakifier = weakifier
+
+            let opaqueWeakifier = Unmanaged.passUnretained(weakifier).toOpaque()
+            
+            let callback: SCNetworkReachabilityCallBack = { (_, flags, info) in
+                guard let info = info else { return }
+
+                let weakifier = Unmanaged<ReachabilityWeakifier>.fromOpaque(info).takeUnretainedValue()
+                weakifier.reachability?.queue.async {
+                    weakifier.reachability?.notifyConnectionChange(flags: flags)
+                }
+            }
+            
+            var context = SCNetworkReachabilityContext(
+                version: 0,
+                info: opaqueWeakifier,
+                retain: { info in
+                    let unmanaged = Unmanaged<ReachabilityWeakifier>.fromOpaque(info)
+                    _ = unmanaged.retain()
+                    return UnsafeRawPointer(unmanaged.toOpaque())
+                },
+                release: { info in
+                    let unmanaged = Unmanaged<ReachabilityWeakifier>.fromOpaque(info)
+                    unmanaged.release()
+                },
+                copyDescription: nil
+            )
+            
+            if !SCNetworkReachabilitySetCallback(reachabilityRef, callback, &context) {
+                throw NSError(domain: "SimpleReachability", code: 2, userInfo: [NSLocalizedDescriptionKey: "Failed to set reachability callback"])
+            }
+            
+            if !SCNetworkReachabilitySetDispatchQueue(reachabilityRef, queue) {
+                throw NSError(domain: "SimpleReachability", code: 3, userInfo: [NSLocalizedDescriptionKey: "Failed to set reachability queue"])
+            }
+            
+            if let flags = currentFlags {
+                notifyConnectionChange(flags: flags)
+            }
+        }
+    }
+    
+    public func stopMonitoring() {
+        queue.sync {
+            SCNetworkReachabilitySetCallback(reachabilityRef, nil, nil)
+            SCNetworkReachabilitySetDispatchQueue(reachabilityRef, nil)
+            weakifier = nil
+        }
+    }
+    
+    // MARK: - Private Methods
+    
+    private func isNetworkReachable(with flags: SCNetworkReachabilityFlags) -> Bool {
+        let isReachable = flags.contains(.reachable)
+        let needsConnection = flags.contains(.connectionRequired)
+        let canConnectAutomatically = flags.contains(.connectionOnDemand) || flags.contains(.connectionOnTraffic)
+        let canConnectWithoutUserInteraction = canConnectAutomatically && !flags.contains(.interventionRequired)
+        
+        return isReachable && (!needsConnection || canConnectWithoutUserInteraction)
+    }
+    
+    private func notifyConnectionChange(flags: SCNetworkReachabilityFlags) {
+        guard flags != previousFlags else { return }
+        previousFlags = flags
+        
+        let isConnected = isNetworkReachable(with: flags)
+        let status: ConnectionStatus = isConnected ? .connected : .disconnected
+        
+        DispatchQueue.main.async { [onConnectionChange] in
+            onConnectionChange?(status)
+        }
+    }
+}
+
+private class ReachabilityWeakifier {
+    weak var reachability: ReachabilityService?
+    init(reachability: ReachabilityService) {
+        self.reachability = reachability
+    }
+}

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Services/TokenService.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Services/TokenService.swift
@@ -1,0 +1,22 @@
+final class TokenService {
+    static func createTokenEndpoint(
+        completion: @escaping (Result<TokenEndpoint, Error>) -> Void
+    ) {
+        do {
+            guard let appKey = try ServiceContainer.shared.storageService.getAppId() else {
+                completion(.failure(DatabaseErrorType.missingAppKey))
+                return
+            }
+
+            guard let consumerId = try ServiceContainer.shared.storageService.getConsumerId() else {
+                completion(.failure(DatabaseErrorType.missingConsumerId))
+                return
+            }
+
+            let token = ConsumerToken(appKey: appKey, consumerId: consumerId)
+            completion(.success(TokenEndpoint(token: token)))
+        } catch {
+            completion(.failure(error))
+        }
+    }
+}

--- a/AppAmbitSdk/Sources/AppAmbitSdk/Storage/Storable.swift
+++ b/AppAmbitSdk/Sources/AppAmbitSdk/Storage/Storable.swift
@@ -143,7 +143,7 @@ class Storable: StorageService {
             guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { throw sqliteError }
             defer { sqlite3_finalize(stmt) }
             
-            bindText(stmt, index: 1, value: event.id.uuidString)
+            bindText(stmt, index: 1, value: event.id)
             bindText(stmt, index: 2, value: event.dataJson)
             bindText(stmt, index: 3, value: event.name)
             bindText(stmt, index: 4, value:  stringFromDateCustom(event.createdAt))
@@ -211,22 +211,24 @@ class Storable: StorageService {
         return try queue.sync {
             var result: [EventEntity] = []
             let sql = """
-            SELECT id, data_json, name, createdAt
+            SELECT id, data_json, name, created_at
             FROM \(EventEntityConfiguration.tableName)
-            ORDER BY createdAt ASC
+            ORDER BY created_at ASC
             LIMIT 100;
             """
             var stmt: OpaquePointer?
-            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else { throw sqliteError }
+            guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+                throw sqliteError
+            }
             defer { sqlite3_finalize(stmt) }
             
             while sqlite3_step(stmt) == SQLITE_ROW {
-                guard
-                    let idCStr = sqlite3_column_text(stmt, 0),
-                    let uuid = UUID(uuidString: String(cString: idCStr)),
-                    let createdAtCStr = sqlite3_column_text(stmt, 3),
-                    let createdAt = dateFromStringCustom(String(cString: createdAtCStr))
-                else { continue }
+                let idString = String(cString: sqlite3_column_text(stmt, 0))
+                let createdAtString = String(cString: sqlite3_column_text(stmt, 3))
+                
+                guard let createdAt = dateFromStringCustom(createdAtString) else {
+                    continue
+                }
                 
                 let dataJson = String(cString: sqlite3_column_text(stmt, 1))
                 let name = String(cString: sqlite3_column_text(stmt, 2))
@@ -236,9 +238,9 @@ class Storable: StorageService {
                    let dict = try? JSONSerialization.jsonObject(with: data) as? [String: String] {
                     metadata = dict
                 }
-                
+            
                 let event = EventEntity(
-                    id: uuid,
+                    id: idString,
                     createdAt: createdAt,
                     name: name,
                     metadata: metadata
@@ -263,17 +265,17 @@ class Storable: StorageService {
             defer { sqlite3_finalize(stmt) }
             
             for event in events {
-                let uuidString = event.id.uuidString.trimmingCharacters(in: .whitespacesAndNewlines)
-                debugPrint("Attempting to delete event with id: \(uuidString)")
+                let idString = event.id.trimmingCharacters(in: .whitespacesAndNewlines)
+                debugPrint("Attempting to delete event with id: \(idString)")
                 
-                bindText(stmt, index: 1, value: uuidString)
+                bindText(stmt, index: 1, value: idString)
                 
                 let stepResult = sqlite3_step(stmt)
                 if stepResult != SQLITE_DONE {
-                    debugPrint("sqlite3_step failed for id: \(uuidString) with result \(stepResult)")
+                    debugPrint("sqlite3_step failed for id: \(idString) with result \(stepResult)")
                     throw sqliteError
                 } else {
-                    debugPrint("Deleted (or did not exist): \(uuidString)")
+                    debugPrint("Deleted (or did not exist): \(idString)")
                 }
                 
                 sqlite3_reset(stmt)

--- a/AppAmbitSdk/Sources/Crashes/Crashes.swift
+++ b/AppAmbitSdk/Sources/Crashes/Crashes.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+public class Crashes {
+    
+    public static func logError(
+        context: Any?,
+        message: String?,
+        properties: [String: String]?,
+        classFqn: String?,
+        exception: NSException?,
+        fileName: String?,
+        lineNumber: Int,
+        createdAt: Date?
+    ) {
+        Logging.logEvent(
+            context: context,
+            message: message,
+            logType: .error,
+            exception: exception,
+            properties: properties,
+            classFqn: classFqn,
+            fileName: fileName,
+            lineNumber: lineNumber,
+            createdAt: createdAt
+        )
+    }
+
+}

--- a/AppAmbitSdk/Sources/Crashes/Logging.swift
+++ b/AppAmbitSdk/Sources/Crashes/Logging.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+final class Logging: Sendable {
+    
+    private nonisolated(unsafe) static let apiService: ApiService = ServiceContainer.shared.apiService
+    private nonisolated(unsafe) static let storable: StorageService = ServiceContainer.shared.storageService
+    private static let queue = DispatchQueue(label: "com.appambit.logging.queue", qos: .utility)
+    private static let tag = "Logging"
+    
+    static func logEvent(
+        context: Any?, // En iOS no se usa Context, así que podría ser opcional o nil
+        message: String?,
+        logType: LogType,
+        exception: NSException?, // en Swift no hay Exception, uso NSException para ejemplo
+        properties: [String: String]?,
+        classFqn: String?,
+        fileName: String?,
+        lineNumber: Int,
+        createdAt: Date?
+    ) {
+        //let exceptionInfo = exception != nil ? ExceptionInfo.from(exception: exception!) : nil
+        logEvent(
+            context: context,
+            message: message,
+            logType: logType,
+            //exceptionInfo: exceptionInfo,
+            properties: properties,
+            classFqn: classFqn,
+            fileName: fileName,
+            lineNumber: lineNumber,
+            createdAt: createdAt
+        )
+    }
+    
+    static func logEvent(
+        context: Any?,
+        message: String?,
+        logType: LogType,
+        //exceptionInfo: ExceptionInfo?,
+        properties: [String: String]?,
+        classFqn: String?,
+        fileName: String?,
+        lineNumber: Int,
+        createdAt: Date?
+    ) {
+        
+     
+        
+        let file = MultipartFile(fileName: "example.txt", mimeType: "text/plain", data: Data("Contenido del archivo".utf8))
+
+        // Obtener info versión app iOS
+        let appVersion: String = {
+            if let info = Bundle.main.infoDictionary {
+                let version = info["CFBundleShortVersionString"] as? String ?? "Unknown"
+                let build = info["CFBundleVersion"] as? String ?? "Unknown"
+                return "\(version) (\(build))"
+            }
+            return "Unknown"
+        }()
+        
+        let log = Log()
+        log.appVersion = appVersion
+        log.classFQN = AppConstants.unknownClass
+        log.fileName = AppConstants.unknownFileName
+        log.lineNumber = 0
+        log.message = message ?? ""
+        log.stackTrace = AppConstants.noStackTraceAvailable
+        log.context = properties ?? [:]
+        log.type = logType
+        log.file = (logType == .crash) ? file : nil
+        
+        sendOrSaveLogEventAsync(log)
+    }
+    
+    private static func sendOrSaveLogEventAsync(_ log: Log) {
+        queue.async {
+            let apiService = ServiceContainer.shared.apiService
+            let logEndpoint = LogEndpoint(log: log)
+            
+            // Creamos una copia inmutable para el closure Sendable
+            let logCopy = log
+            
+            apiService.executeRequest(logEndpoint, responseType: LogResponse.self) { result in
+                
+                if result.errorType != .none {
+                    debugPrint("\(tag): Save on datbase Log: \(result.message ?? "")")
+                    return
+                }
+                
+                debugPrint("\(tag): Log send")
+            }
+        }
+    }
+
+    private static func storeLogInDb(log: LogEntity) {
+        do {
+            try storable.putLogEvent(log)
+            debugPrint("\(tag): Log event stored in database")
+        } catch {
+            debugPrint("\(tag): Failed to store log event: \(error.localizedDescription)")
+        }
+    }
+
+    private static func storeLogInDb(_ log: LogEntity, storable: StorageService) {
+        queue.async {
+            do {
+                try storable.putLogEvent(log)
+                print("\(tag): Log event stored in database")
+            } catch {
+                print("\(tag): Failed to store log event: \(error.localizedDescription)")
+            }
+        }
+    }
+
+}

--- a/AppAmbitTestApp/AnalyticsView.swift
+++ b/AppAmbitTestApp/AnalyticsView.swift
@@ -1,12 +1,88 @@
 import SwiftUI
+import AppAmbit
 
 struct AnalyticsView: View {
+    @State private var showCompletionAlert = false
+    
     var body: some View {
         VStack(spacing: 25) {
-            Text("Analytics View")
-                .padding()
-                .background(Color.teal, in: RoundedRectangle.init(cornerRadius: 10))
+            Button("Invalidate Token") {
+                Analytics.clearToken()
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.blue)
+            .foregroundColor(.white)
+            .cornerRadius(8)
+            .padding(.horizontal)
+            
+            Button("Token refresh test") {
+                onTokenRefreshTest()
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.blue)
+            .foregroundColor(.white)
+            .cornerRadius(8)
+            .padding(.horizontal)
         }
         .padding()
+        .alert(isPresented: $showCompletionAlert) {
+            Alert(
+                title: Text("Info"),
+                message: Text("5 events and 5 errors sent"),
+                dismissButton: .default(Text("OK"))
+            )
+        }
+    }
+    
+    private func onTokenRefreshTest() {
+        let group = DispatchGroup()
+        let queue = DispatchQueue.global(qos: .utility)
+
+        Analytics.clearToken()
+
+       print("[Test] Enviando 5 logs concurrentes con token vacío")
+        for i in 1...5 {
+            group.enter()
+            queue.async {
+                Crashes.logError(
+                    context: nil,
+                    message: "Sending logs 5 after invalid token",
+                    properties: ["user_id": "1"],
+                    classFqn: "AnalyticsView",
+                    exception: nil,
+                    fileName: nil,
+                    lineNumber: 0,
+                    createdAt: Date()
+                )
+                group.leave()
+            }
+        }
+
+       group.notify(queue: .main) {
+            print("[Test] Terminó batch de Logs. Limpiando token para Events.")
+            Analytics.clearToken()
+
+            let eventGroup = DispatchGroup()
+
+            print("[Test] Enviando 5 eventos concurrentes con token vacío")
+            for i in 1...5 {
+                eventGroup.enter()
+                queue.async {
+                    Analytics.trackEvent(
+                        eventTitle: "Sending events 5 after invalid token",
+                        data: ["Test Token": "5 events sent"],
+                        createdAt: nil
+                    )
+                    eventGroup.leave()
+                }
+            }
+
+            eventGroup.notify(queue: .main) {
+                print("[Test] Se enviaron 5 logs y 5 eventos con renovación de token en concurrencia.")
+                showCompletionAlert = true
+            }
+        }
     }
 }

--- a/AppAmbitTestApp/AppAmbitTestingApp.swift
+++ b/AppAmbitTestApp/AppAmbitTestingApp.swift
@@ -4,7 +4,7 @@ import AppAmbit;
 @main
 struct AppAmbitTestingApp: App {
     init() {
-        AppAmbit.start(appKey: "7bba5bdc-0f0b-4770-8d59-1c4a62549311")
+        AppAmbit.start(appKey: "5034073e-1573-474e-b9a4-7bf7fa432ee5")
     }
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [ ] 🛠️ Refactor
* [x] ✨ Feature
* [ ] 🐛 Bug Fix
* [ ] ⚡ Optimization
* [ ] 📚 Documentation Update

## Description

This PR implements a new **token renewal flow** with support for **parallel request handling** and fallback strategies. It also improves the token acquisition mechanism to separate consumer creation from token retrieval in subsequent sessions.

### ✅ Implemented:

#### 🔒 Token Renewal Logic

* Added a mechanism to **invalidate the token manually** for testing.
* When sending **multiple events/logs in parallel**, only **one request triggers token renewal**.
* Once renewed, the token is **shared with remaining requests**, which skip renewal and continue as normal.

#### 🔁 New Token Fetch Strategy

* On **first app launch**, the SDK:

  * Creates a **new consumer**.
  * Retrieves a token from the **consumer creation endpoint**.
  * Stores the token **in memory** (valid during app lifecycle only).
* On **subsequent launches**, if a `consumerId` is found:

  * The SDK fetches a **new token using the consumerId and appKey**, via a **dedicated endpoint**.
  * This avoids unnecessary consumer creation and uses the optimized flow.

#### 🧪 UI Integration

* Added **two buttons** under the **Analytics tab**:

  * **Invalidate Token**
  * **Token refresh test** (sends 5 logs + 5 events)

## Related Tickets & Documents

* [[ID-XXX](https://app.asana.com/...)](https://app.asana.com/...) ← (puedes insertar el enlace real)
* Prepares ground for improving event reliability and authentication robustness.

## QA Instructions, Screenshots, Recordings

✅ **Manual verification steps**:

1. Open the app
2. Navigate to the **Analytics tab**
3. Tap **"Invalidate Token"** → this clears the token to simulate expiry
4. Tap **"Token refresh test"**
5. The UI confirms that **5 logs** and **5 events** were sent
6. Visit the **dashboard** to confirm logs/events with the following names:

   * `Sending events 5 after invalid token`
   * `Sending logs 5 after invalid token`
7. You can also observe the internal token renewal behavior through logs if running locally.

✅ Expected Result:

* Only one request performs the **token renewal**.
* Remaining requests reuse the renewed token without duplicating the refresh.
* All events/logs are delivered successfully.

## Added/updated tests?

* [ ] ✅ Yes
* [x] ❌ No, and this is why: behavior tested manually and verified via logs + dashboard
* [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?

* [ ] 📝 Yes (please add details)
* [x] ❌ No
* [ ] ❓ I don't know

## \[optional] What gif best describes this PR or how it makes you feel?

![teamwork-token](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExdGVkOWR1NGRwbjJnNzB4N2xodDd3dnU2NGI4MWNmcjU5eXVoMDd4dyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/gRUvUqTZDUEGrGVLLf/giphy.gif)
