### PR TITLE
chore: updated new version with production url

### DIFF
--- a/AppAmbitSdk/AppAmbitSdk.podspec
+++ b/AppAmbitSdk/AppAmbitSdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppAmbitSdk'
-  s.version          = '0.0.7'
+  s.version          = '0.0.8'
   s.summary          = 'Lightweight SDK for capturing sessions, logs, crashes, and events in iOS apps with offline persistence and batch upload to AppAmbit.'
 
   s.description      = <<-DESC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,34 +1,4 @@
-## Version 0.0.7
+## Version 0.0.8
 
 ### Changes
-- Fix: Changes to the CI/CD workflow
-
-## Version 0.0.6
-
-### Changes
-- Fix: changelog rendering on cocoapods.org.
-
-## Version 0.0.5
-
-### Changes
-- Fixing changelog versioning.
-
-## Version 0.0.4
-
-### Changes
-- Changes in README.md.
-
-## Version 0.0.3
-
-### Changes
-- Changes in the podspec.
-
-## Version 0.0.2
-
-### Changes
-- LICENSE and README.md moved.
-
-## Version 0.0.1
-
-### Changes
-- First publication.
+- AppAmbit release


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [X] 🛠️ Refactor
* [ ] ✨ Feature
* [ ] 🐛 Bug Fix
* [ ] ⚡ Optimization
* [ ] 📚 Documentation Update

---

## Description

This PR updates the **CocoaPod library version to `0.0.8`** and introduces the new **production URL** for the SDK.

---

### ✅ Implemented:

* Bumped CocoaPod version → **0.0.8**.
* Updated SDK configuration to use the new **production endpoint**.
* Ensured consistency with release workflow for CocoaPods.

---

## Related Tickets & Documents

- [ID-1254](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1211429703060367)
- Closes #1254


## QA Instructions, Screenshots, Recordings

### ✅ How to Test

1. Update your Podfile to use the new version:

   ```ruby
   pod 'AppAmbitSdk', '0.0.8'
   ```
2. Run `pod install`.
3. Verify that:

   * The SDK resolves correctly with version **0.0.8**.
   * Requests are being sent to the **new production URL**.

---

## ✅ Expected Result

* The CocoaPod library installs version **0.0.8**.
* All SDK requests use the updated **production URL**.
* No regressions or compatibility issues with Objective-C or Swift apps.

---

## Added/updated tests?

* [ ] ✅ Yes
* [x] ❌ No – version bump and endpoint change validated manually
* [ ] 🤔 I need help with writing tests

---

## Are there any post deployment tasks we need to perform?

* [x] 📝 Yes → Publish CocoaPod version `0.0.8` to CocoaPods.org
* [ ] ❌ No
* [ ] ❓ I don't know

---

## \[optional] What gif best describes this PR or how it makes you feel?

![version-bump](https://media.giphy.com/media/3o7aCTfyhYawdOXcFW/giphy.gif)
