### PR TITLE
ID-1305: Refactor - Added new methods for Objc in the Crashes class

### DIFF
--- a/AppAmbitSdk/Sources/Crashes.swift
+++ b/AppAmbitSdk/Sources/Crashes.swift
@@ -5,7 +5,7 @@ import UIKit
 @objcMembers
 public final class Crashes: NSObject, @unchecked Sendable {
     
-    // MARK: - Objetive-C API
+    // MARK: - Objective-C
 
     @preconcurrency
     @objc(logErrorWithMessage:completion:)

--- a/AppAmbitSdk/Sources/Crashes.swift
+++ b/AppAmbitSdk/Sources/Crashes.swift
@@ -4,7 +4,74 @@ import UIKit
 
 @objcMembers
 public final class Crashes: NSObject, @unchecked Sendable {
+    
+    // MARK: - Objetive-C API
 
+    @preconcurrency
+    @objc(logErrorWithMessage:completion:)
+    public static func objc_logError(message: String,
+                                     completion: (@Sendable () -> Void)?)
+    {
+        self.logError(message: message,
+                      properties: nil,
+                      classFqn: nil,
+                      exception: nil,
+                      fileName: nil,
+                      lineNumber: #line) { _ in
+            if let completion { DispatchQueue.main.async { completion() } }
+        }
+    }
+
+    @preconcurrency
+    @objc(logErrorWithMessage:properties:completion:)
+    public static func objc_logError(message: String,
+                                     properties: [String: String]?,
+                                     completion: (@Sendable () -> Void)?)
+    {
+        self.logError(message: message,
+                      properties: properties,
+                      classFqn: nil,
+                      exception: nil,
+                      fileName: nil,
+                      lineNumber: #line) { _ in
+            if let completion { DispatchQueue.main.async { completion() } }
+        }
+    }
+
+    @preconcurrency
+    @objc(logErrorWithMessage:properties:classFqn:completion:)
+    public static func objc_logError(message: String,
+                                     properties: [String: String]?,
+                                     classFqn: String?,
+                                     completion: (@Sendable () -> Void)?)
+    {
+        self.logError(message: message,
+                      properties: properties,
+                      classFqn: classFqn,
+                      exception: nil,
+                      fileName: nil,
+                      lineNumber: #line) { _ in
+            if let completion { DispatchQueue.main.async { completion() } }
+        }
+    }
+
+    @preconcurrency
+    @objc(logErrorWithNSException:properties:classFqn:completion:)
+    public static func objc_logError(nsException: NSException,
+                                     properties: [String: String]?,
+                                     classFqn: String?,
+                                     completion: (@Sendable () -> Void)?)
+    {
+        self.logError(nsException: nsException,
+                      properties: properties,
+                      classFqn: classFqn,
+                      fileName: nil,
+                      lineNumber: #line) { _ in
+            if let completion { DispatchQueue.main.async { completion() } }
+        }
+    }
+
+    
     // MARK: - Singleton
     public static let shared = Crashes()
 

--- a/AppAmbitTestAppObjC/AppDelegate.m
+++ b/AppAmbitTestAppObjC/AppDelegate.m
@@ -13,7 +13,7 @@
     // Uncomment the line for manual session management
     //[Analytics enableManualSession];
 
-    [AppAmbit startWithAppKey:@"<YOUR-APPKEY>"];
+    [AppAmbit startWithAppKey:@"c4cfa29a-137f-450f-a258-626fa851cf9e"];
 
     return YES;
 }

--- a/AppAmbitTestAppObjC/AppDelegate.m
+++ b/AppAmbitTestAppObjC/AppDelegate.m
@@ -13,7 +13,7 @@
     // Uncomment the line for manual session management
     //[Analytics enableManualSession];
 
-    [AppAmbit startWithAppKey:@"c4cfa29a-137f-450f-a258-626fa851cf9e"];
+    [AppAmbit startWithAppKey:@"<YOUR-APPKEY>"];
 
     return YES;
 }

--- a/AppAmbitTestAppObjC/CrashesViewController.m
+++ b/AppAmbitTestAppObjC/CrashesViewController.m
@@ -146,8 +146,6 @@
     [Analytics setEmail:email completion:nil];
 }
 
-#pragma mark - NUEVAS llamadas limpias con completion (sin error)
-
 - (void)onSendCustomLogError {
     NSString *msg = self.messageField.text ?: @"";
     [Crashes logErrorWithMessage:msg completion:^{
@@ -192,8 +190,6 @@
         [self presentInfo];
     }];
 }
-
-#pragma mark - Otros botones
 
 - (void)onGenerate30DaysTestErrorsOC {
 }

--- a/AppAmbitTestAppObjC/CrashesViewController.m
+++ b/AppAmbitTestAppObjC/CrashesViewController.m
@@ -21,7 +21,6 @@
     [super viewDidLoad];
     self.title = @"Crashes";
     self.view.backgroundColor = [UIColor systemBackgroundColor];
-
     [self buildUI];
 }
 
@@ -123,6 +122,8 @@
     return tf;
 }
 
+#pragma mark - Actions
+
 - (void)onDidCrashInLastSession {
     [Crashes didCrashInLastSessionWithCompletion:^(BOOL didCrash) {
         self.alertMessage = didCrash ?
@@ -145,11 +146,12 @@
     [Analytics setEmail:email completion:nil];
 }
 
+#pragma mark - NUEVAS llamadas limpias con completion (sin error)
+
 - (void)onSendCustomLogError {
     NSString *msg = self.messageField.text ?: @"";
-    [Crashes logErrorWithMessage:msg properties:nil classFqn:nil exception:nil fileName:nil lineNumber:0 completion:^(NSError * _Nullable error) {
-        if (error) NSLog(@"[CrashesView] Error sending Log Error: %@", error.localizedDescription);
-        else NSLog(@"[CrashesView] Log Error sent successfully");
+    [Crashes logErrorWithMessage:msg completion:^{
+        NSLog(@"[CrashesView] Log Error sent");
         self.alertMessage = @"LogError Sent";
         [self presentInfo];
     }];
@@ -157,9 +159,8 @@
 
 - (void)onSendDefaultLog {
     NSDictionary<NSString *, NSString *> *props = @{ @"user_id": @"1" };
-    [Crashes logErrorWithMessage:@"Test Log Error" properties:props classFqn:nil exception:nil fileName:nil lineNumber:0 completion:^(NSError * _Nullable error) {
-        if (error) NSLog(@"[CrashesView] Error sending Log Error: %@", error.localizedDescription);
-        else NSLog(@"[CrashesView] Log Error sent successfully");
+    [Crashes logErrorWithMessage:@"Test Log Error" properties:props completion:^{
+        NSLog(@"[CrashesView] Log Error sent");
         self.alertMessage = @"LogError Sent";
         [self presentInfo];
     }];
@@ -170,20 +171,29 @@
         [NSException raise:NSInternalInconsistencyException format:@"Test error Exception Objective C"];
     }
     @catch (NSException *ex) {
-        [Crashes logErrorWithNsException:ex properties:@{ @"user_id": @"1" } classFqn:NSStringFromClass(self.class) fileName:[NSString stringWithUTF8String:__FILE__] lineNumber:@(__LINE__).longLongValue completion:^(NSError * _Nullable err) {
-            NSLog(@"%@", err ? err.localizedDescription : @"OK");
+        [Crashes logErrorWithNSException:ex
+                              properties:@{ @"user_id": @"1" }
+                                 classFqn:NSStringFromClass(self.class)
+                              completion:^{
+            NSLog(@"[CrashesView] Exception Log sent");
+            self.alertMessage = @"LogError Sent";
+            [self presentInfo];
         }];
     }
 }
 
 - (void)onSendClassInfoLog {
-    [Crashes logErrorWithMessage:@"Test Log Error" properties:@{ @"user_id": @"1" } classFqn:nil exception:nil fileName:@(__FILE__) lineNumber:__LINE__ completion:^(NSError * _Nullable error) {
-        if (error) NSLog(@"Error sending Log Error: %@", error.localizedDescription);
-        else NSLog(@"Log Error sent successfully");
+    [Crashes logErrorWithMessage:@"Test Log Error"
+                      properties:@{ @"user_id": @"1" }
+                         classFqn:NSStringFromClass(self.class)
+                      completion:^{
+        NSLog(@"[CrashesView] Log Error sent");
         self.alertMessage = @"LogError Sent";
         [self presentInfo];
     }];
 }
+
+#pragma mark - Otros botones
 
 - (void)onGenerate30DaysTestErrorsOC {
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

* [x] 🛠️ Refactor
* [ ] ✨ Feature
* [ ] 🐛 Bug Fix
* [ ] ⚡ Optimization
* [ ] 📚 Documentation Update

## Description

New Objective-C friendly methods were created in the Swift library to register errors with only the required parameters, avoiding passing `nil` for unused ones.

The following methods were added in Swift:

```swift
public static func objc_logError(message: String,
                                 completion: (@Sendable () -> Void)?)

public static func objc_logError(message: String,
                                 properties: [String: String]?,
                                 completion: (@Sendable () -> Void)?)

public static func objc_logError(message: String,
                                 properties: [String: String]?,
                                 classFqn: String?,
                                 completion: (@Sendable () -> Void)?)

public static func objc_logError(nsException: NSException,
                                 properties: [String: String]?,
                                 classFqn: String?,
                                 completion: (@Sendable () -> Void)?)
```

This applies to the **Crashes tab**, where you can validate correct functionality by executing the following buttons:

* **Send Custom LogError**
* **Send Default LogError**
* **Send Exception LogError**
* **Send ClassInfo LogError**

---

## Related Tickets & Documents

* [ID-1305](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1211517103832658)
* Closes #1305
---

## QA Instructions, Screenshots, Recordings

1. Open the app and navigate to the **Crashes tab**.
2. Run the following test buttons:

   * Send Custom LogError
   * Send Default LogError
   * Send Exception LogError
   * Send ClassInfo LogError
3. Verify that logs are properly registered without requiring unused parameters (`nil`).

---

## ✅ Expected Result

* Error logs can be registered from Objective-C using only the required parameters.
* No need to pass unused values (`nil`).
* Buttons in **Crashes tab** correctly trigger the new methods.

---

## Added/updated tests?

* [ ] ✅ Yes
* [x] ❌ No, and this is why: validated manually through Crashes tab test buttons
* [ ] 🤔 I need help with writing tests

---

## Are there any post deployment tasks we need to perform?

* [ ] 📝 Yes (please add details)
* [x] ❌ No
* [ ] ❓ I don't know

---

## [optional] What gif best describes this PR or how it makes you feel?

![objc-bridge](https://media.giphy.com/media/l41lI4bYmcsPJX9Go/giphy.gif)
