### PR TITLE
feat(push): split extension-safe podspec and buffer cold-start notifi…

### DIFF
--- a/Push/AppAmbitPushNotifications/AppAmbitPushNotifications.podspec
+++ b/Push/AppAmbitPushNotifications/AppAmbitPushNotifications.podspec
@@ -16,21 +16,10 @@ Pod::Spec.new do |spec|
   spec.ios.deployment_target = '12.0'
   spec.swift_version  = '5.7'
 
-  spec.default_subspec = 'Core'
-
-  # Full SDK — for the host app. Includes Core/Delegate/Extension code and
-  # depends on the main AppAmbit SDK.
-  spec.subspec 'Core' do |c|
-    c.source_files = 'Sources/**/*.swift'
-    c.dependency 'AppAmbitSdk'
-  end
-
-  # Extension-only — for the Notification Service Extension target.
-  # Self-contained (no AppAmbitSdk / no Core dependency) and compiled with
-  # APPLICATION_EXTENSION_API_ONLY so it cannot accidentally reference APIs
-  # forbidden in app extensions.
-  spec.subspec 'Extension' do |e|
-    e.source_files = 'Sources/Extension/*.swift'
-    e.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
-  end
+  # Full SDK for the host app (Core + Delegate + Extension).
+  # Not extension-safe — references UIApplication and other APIs forbidden
+  # in Notification Service Extensions. For NSE targets use the
+  # `AppAmbitPushNotificationsExtension` pod instead.
+  spec.source_files = 'Sources/**/*.swift'
+  spec.dependency 'AppAmbitSdk'
 end

--- a/Push/AppAmbitPushNotifications/AppAmbitPushNotificationsExtension.podspec
+++ b/Push/AppAmbitPushNotifications/AppAmbitPushNotificationsExtension.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |spec|
+  spec.name         = "AppAmbitPushNotificationsExtension"
+  spec.version      = "0.5.0"
+  spec.summary      = "Extension-safe slice of AppAmbitPushNotifications for iOS Notification Service Extensions."
+
+  spec.description  = <<-DESC
+  Extension-only subset of the AppAmbit Push Notifications SDK, compiled with
+  APPLICATION_EXTENSION_API_ONLY = YES so it can be linked into a Notification
+  Service Extension target. Provides the `AppAmbitNotificationService` base
+  class, `AppAmbitNotification` model and `PushNotificationAttachments` helper.
+
+  Self-contained: depends only on UserNotifications and Foundation. Does not
+  pull in the main AppAmbit SDK.
+                   DESC
+
+  spec.homepage     = "https://github.com/AppAmbit/appambit-sdk-ios"
+  spec.license          = { :type => 'MIT', :file => 'LICENSE' }
+  spec.author           = { 'AppAmbit Inc' => 'hello@appambit.com' }
+  spec.source           = { :git => 'https://github.com/AppAmbit/appambit-sdk-ios.git', :tag => spec.version.to_s }
+
+  spec.ios.deployment_target = '12.0'
+  spec.swift_version  = '5.7'
+
+  spec.source_files = 'Sources/Extension/*.swift'
+  spec.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
+end

--- a/Push/AppAmbitPushNotifications/Sources/Core/PushKernel.swift
+++ b/Push/AppAmbitPushNotifications/Sources/Core/PushKernel.swift
@@ -12,6 +12,9 @@ public class PushKernel: NSObject {
     private nonisolated(unsafe) static var tokenListener: TokenListener?
     private nonisolated(unsafe) static var lastKnownPermission: Bool = UserDefaults.standard.bool(forKey: "com.appambit.push.permission")
     private nonisolated(unsafe) static var notificationListener: (([AnyHashable: Any], PushNotificationState) -> Void)?
+    /// Notifications that arrived (typically as cold-start taps) before any
+    /// listener was registered. Replayed when `setNotificationListener` runs.
+    private nonisolated(unsafe) static var pendingNotifications: [(userInfo: [AnyHashable: Any], state: PushNotificationState)] = []
 
     // MARK: - Protocols
     
@@ -110,12 +113,24 @@ public class PushKernel: NSObject {
 
     @objc public static func setNotificationListener(_ listener: @escaping ([AnyHashable: Any], PushNotificationState) -> Void) {
         notificationListener = listener
+        // Drain any notifications that arrived before the listener was set
+        // (typically a cold-start tap that fired the UN delegate while the
+        // Flutter engine / Dart isolate was still bootstrapping).
+        let drained = pendingNotifications
+        pendingNotifications = []
+        for item in drained {
+            listener(item.userInfo, item.state)
+        }
     }
 
     // MARK: - Internal Dispatch
 
     internal static func notifyNotificationReceived(userInfo: [AnyHashable: Any], state: PushNotificationState) {
         PushLogger.log("Notification dispatched -> state: \(state == .foreground ? "foreground" : "opened")")
-        notificationListener?(userInfo, state)
+        if let listener = notificationListener {
+            listener(userInfo, state)
+        } else {
+            pendingNotifications.append((userInfo, state))
+        }
     }
 }


### PR DESCRIPTION
What type of PR is this? (check all applicable)
* [x] 🛠️ Refactor
* [ ] ✨ Feature
* [ ] 🐛 Bug Fix
* [x] ⚡ Optimization
* [ ] 📚 Documentation Update

## Description

This PR splits the CocoaPods distribution of `AppAmbitPushNotifications` into two separate podspecs and fixes cold-start notification taps being dropped before the host app finishes bootstrapping.

New Podspecs

The previous `Core`/`Extension` subspec layout has been removed in favor of two independent pods:

- `AppAmbitPushNotifications` — full SDK for the host app (Core + Delegate + Extension). Depends on AppAmbitSdk. **Not extension-safe**: references `UIApplication` and other APIs forbidden in Notification Service Extensions.
- `AppAmbitPushNotificationsExtension` — extension-safe slice for NSE targets only. Ships `Sources/Extension/*` compiled with `APPLICATION_EXTENSION_API_ONLY = YES`. Self-contained — no dependency on AppAmbitSdk. Exposes `AppAmbitNotificationService`, `AppAmbitNotification`, and `PushNotificationAttachments`.

Consumers integrating a Notification Service Extension must now link `AppAmbitPushNotificationsExtension` instead of the previous `AppAmbitPushNotifications/Extension` subspec.

New Behavior

`PushKernel` now buffers notifications dispatched before any listener is registered and replays them on `setNotificationListener`. This fixes cold-start taps where the UN delegate fires while the Flutter engine / Dart isolate (or any host runtime) is still bootstrapping, causing the notification to be silently dropped.

Changed Methods

`setNotificationListener(_ listener: ([AnyHashable: Any], PushNotificationState) -> Void)`

Drains any pending notifications captured before registration and forwards them to the listener in arrival order.

`notifyNotificationReceived(userInfo:state:)` (internal)

Appends to a pending buffer when no listener is set, instead of being a no-op.

## Related Tickets & Documents
- [ID-1658](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1214904274339510?focus=true)
- Closes #1658

## QA Instructions, Screenshots, Recordings
- Install the host app via `AppAmbitPushNotifications` pod → push arrives in foreground → `.foreground` fires
- Tap a notification from background → `.opened` fires
- Cold-start tap (app killed) → notification is buffered and `.opened` fires as soon as the host registers its listener (no more dropped taps)
- Build a Notification Service Extension target linking `AppAmbitPushNotificationsExtension` → compiles cleanly with `APPLICATION_EXTENSION_API_ONLY = YES` and does not pull in AppAmbitSdk

Added/updated tests?
We encourage you to keep the code coverage percentage at 80% and above.

 ❌ No, and this is why: validated manually through foreground, background, and cold-start scenarios on both the Swift and ObjC sample apps.
 🤔 I need help with writing tests

Are there any post deployment tasks we need to perform?
 ✅ Yes — publish the new `AppAmbitPushNotificationsExtension` pod to the spec repo alongside `AppAmbitPushNotifications` `0.5.0`, and update integration docs to point NSE targets at the new pod name.

[optional] What gif best describes this PR or how it makes you feel?
<img src="https://media.giphy.com/media/xT9IgG50Lg7russbDa/giphy.gif" alt="Alt Text">

Completed: *Draft PR description* (2/3)