### PR TITLE
fix(project): restore missing package reference for AppAmbitPushNot

### DIFF
--- a/AppAmbit.xcodeproj/project.pbxproj
+++ b/AppAmbit.xcodeproj/project.pbxproj
@@ -999,6 +999,7 @@
 		};
 		7928260B2FAEAB8C00766B64 /* AppAmbitPushNotifications */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 79E047D82EF50C00007952FD /* XCLocalSwiftPackageReference "Push/AppAmbitPushNotifications" */;
 			productName = AppAmbitPushNotifications;
 		};
 		79C6A7CA2E7D34AE001EDDD2 /* AppAmbit */ = {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ✨ Feature
- [ ] 🛠️ Refactor
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

## Related Tickets & Documents

- [ID-1678](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1215345280769108)
- Closes #1678

---

## Description

The `project.pbxproj` had a duplicate `XCSwiftPackageProductDependency` entry for `AppAmbitPushNotifications` (`7928260B`) missing its `package` reference. Xcode reported _"Missing package product 'AppAmbitPushNotifications'"_ on all targets.

Added the missing `package = 79E047D82EF50C00007952FD` pointer so the entry correctly resolves to the local `Push/AppAmbitPushNotifications` package.

Root cause: side effect of editing `project.pbxproj` during the CMS cache refactor (`20878b3`).


## Added/updated tests?

- [ ] ✅ Yes
- [x] ❌ No, and this is why: this PR includes a targeted logic fix plus reference cleanup, no new test suite changes
- [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?

- [ ] 📝 Yes (please add details)
- [x] ❌ No
- [ ] ❓ I don't know