### PR TITLE
ID-1681: Bugfix - Include PushLogger in extension podspec

### DIFF
--- a/Push/AppAmbitPushNotifications/AppAmbitPushNotificationsExtension.podspec
+++ b/Push/AppAmbitPushNotifications/AppAmbitPushNotificationsExtension.podspec
@@ -23,7 +23,9 @@ Pod::Spec.new do |spec|
 
   spec.source_files = [
     'Sources/Extension/*.swift',
-    'Push/AppAmbitPushNotifications/Sources/Extension/*.swift'
+    'Sources/Core/PushLogger.swift',
+    'Push/AppAmbitPushNotifications/Sources/Extension/*.swift',
+    'Push/AppAmbitPushNotifications/Sources/Core/PushLogger.swift'
   ]
   spec.pod_target_xcconfig = { 'APPLICATION_EXTENSION_API_ONLY' => 'YES' }
 end


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ✨ Feature
- [ ] 🛠️ Refactor
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

## Related Tickets & Documents

- [ID-1681](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1215375530907845?focus=true)
- Closes #ID-1681

---

## Description

Add PushLogger.swift to the AppAmbitPushNotificationsExtension podspec source_files so the PushLogger implementation is compiled into the extension target. The entries 'Sources/Core/PushLogger.swift' and 'Push/AppAmbitPushNotifications/Sources/Core/PushLogger.swift' were added to ensure the logger is included for the extension build.

## Added/updated tests?

- [ ] ✅ Yes
- [x] ❌ No, and this is why: is a release
- [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?
- [ ] 📝 Yes (please add details)
- [x] ❌ No
- [ ] ❓ I don't know