### PR TITLE
ID-1661: Feature: add root Package.swift for SPM distribution to main branch

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,4 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [AppAmbit, AppAmbitPushNotifications]

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,10 @@ let package = Package(
             name: "AppAmbitPushNotifications",
             targets: ["AppAmbitPushNotifications"]
         ),
+        .library(
+            name: "AppAmbitPushNotificationsExtension",
+            targets: ["AppAmbitPushNotificationsExtension"]
+        ),
     ],
     targets: [
         .target(
@@ -25,6 +29,10 @@ let package = Package(
             name: "AppAmbitPushNotifications",
             dependencies: ["AppAmbit"],
             path: "Push/AppAmbitPushNotifications/Sources"
+        ),
+        .target(
+            name: "AppAmbitPushNotificationsExtension",
+            path: "PushExtensionSources"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "AppAmbitSdk",
+    platforms: [
+        .iOS(.v12)
+    ],
+    products: [
+        .library(
+            name: "AppAmbit",
+            targets: ["AppAmbit"]
+        ),
+        .library(
+            name: "AppAmbitPushNotifications",
+            targets: ["AppAmbitPushNotifications"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "AppAmbit",
+            path: "AppAmbitSdk/Sources"
+        ),
+        .target(
+            name: "AppAmbitPushNotifications",
+            dependencies: ["AppAmbit"],
+            path: "Push/AppAmbitPushNotifications/Sources"
+        ),
+    ]
+)

--- a/PushExtensionSources/AppAmbitNotification.swift
+++ b/PushExtensionSources/AppAmbitNotification.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Represents an AppAmbit notification payload.
+@objc(AppAmbitNotification)
+@objcMembers
+public final class AppAmbitNotification: NSObject {
+    public let title: String?
+    public let body: String?
+    public let imageUrl: String?
+    public let data: [AnyHashable: Any]
+
+    public init(title: String?, body: String?, imageUrl: String?, data: [AnyHashable: Any]) {
+        self.title = title
+        self.body = body
+        self.imageUrl = imageUrl
+        self.data = data
+        super.init()
+    }
+
+    public static func from(userInfo: [AnyHashable: Any]) -> AppAmbitNotification {
+        let aps = userInfo["aps"] as? [String: Any]
+        let alert = aps?["alert"] as? [String: Any]
+
+        let title = alert?["title"] as? String
+        let body = alert?["body"] as? String
+
+        let imageUrl = userInfo["image"] as? String
+
+        var data = userInfo
+        data.removeValue(forKey: "image")
+
+        return AppAmbitNotification(
+            title: title,
+            body: body,
+            imageUrl: imageUrl,
+            data: data
+        )
+    }
+}

--- a/PushExtensionSources/AppAmbitNotificationProcessor.swift
+++ b/PushExtensionSources/AppAmbitNotificationProcessor.swift
@@ -1,0 +1,42 @@
+import UserNotifications
+
+/// ObjC-callable processor. Use from a `UNNotificationServiceExtension` subclass when
+/// subclasing `AppAmbitNotificationService` is not possible (e.g. ObjC extensions).
+@objc(AppAmbitNotificationProcessor)
+@objcMembers
+public final class AppAmbitNotificationProcessor: NSObject {
+
+    @objc(processRequest:contentHandler:handlePayload:)
+    public static func process(
+        request: UNNotificationRequest,
+        contentHandler: @escaping (UNNotificationContent) -> Void,
+        handlePayload: ((AppAmbitNotification, UNMutableNotificationContent) -> Void)? = nil
+    ) {
+        PushLogger.log("Service Extension triggered.")
+
+        guard let content = request.content.mutableCopy() as? UNMutableNotificationContent else {
+            contentHandler(request.content)
+            return
+        }
+
+        let notification = AppAmbitNotification.from(userInfo: content.userInfo)
+        handlePayload?(notification, content)
+        attachImageIfNeeded(notification, content: content, contentHandler: contentHandler)
+    }
+
+    private static func attachImageIfNeeded(_ notification: AppAmbitNotification,
+                                            content: UNMutableNotificationContent,
+                                            contentHandler: @escaping (UNNotificationContent) -> Void) {
+        guard let imageUrl = notification.imageUrl, !imageUrl.isEmpty else {
+            contentHandler(content)
+            return
+        }
+
+        PushNotificationAttachments.loadImageAttachment(from: imageUrl) { attachment in
+            if let attachment {
+                content.attachments = [attachment]
+            }
+            contentHandler(content)
+        }
+    }
+}

--- a/PushExtensionSources/AppAmbitNotificationService.swift
+++ b/PushExtensionSources/AppAmbitNotificationService.swift
@@ -1,0 +1,59 @@
+import UserNotifications
+
+/// Base class for the AppAmbit Notification Service Extension.
+///
+/// Subclass this from your NSE target to enable rich notifications. The base
+/// class downloads any image referenced by the push payload (`image` key) and
+/// attaches it to the notification before delivery.
+///
+/// Override `handlePayload(_:content:)` to mutate notification content
+/// (title, body, badge, threadIdentifier, etc.) before delivery.
+open class AppAmbitNotificationService: UNNotificationServiceExtension {
+    private static let tag = "[AppAmbitPushSDK]"
+
+    private var contentHandler: ((UNNotificationContent) -> Void)?
+    private var bestAttemptContent: UNMutableNotificationContent?
+
+    open override func didReceive(_ request: UNNotificationRequest,
+                                  withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
+        self.contentHandler = contentHandler
+        self.bestAttemptContent = request.content.mutableCopy() as? UNMutableNotificationContent
+
+        guard let content = bestAttemptContent else {
+            contentHandler(request.content)
+            return
+        }
+
+        let notification = AppAmbitNotification.from(userInfo: content.userInfo)
+        handlePayload(notification, content: content)
+        attachImageIfNeeded(notification, content: content, contentHandler: contentHandler)
+    }
+
+    open override func serviceExtensionTimeWillExpire() {
+        if let bestAttemptContent {
+            contentHandler?(bestAttemptContent)
+        }
+    }
+
+    /// Hook for subclasses to mutate `content` before delivery. Default: no-op.
+    open func handlePayload(_ notification: AppAmbitNotification,
+                            content: UNMutableNotificationContent) {
+        // Subclasses can mutate content here before delivery.
+    }
+
+    private func attachImageIfNeeded(_ notification: AppAmbitNotification,
+                                     content: UNMutableNotificationContent,
+                                     contentHandler: @escaping (UNNotificationContent) -> Void) {
+        guard let imageUrl = notification.imageUrl, !imageUrl.isEmpty else {
+               contentHandler(content)
+            return
+        }
+
+        PushNotificationAttachments.loadImageAttachment(from: imageUrl) { attachment in
+            if let attachment {
+                content.attachments = [attachment]
+            }
+            contentHandler(content)
+        }
+    }
+}

--- a/PushExtensionSources/PushLogger.swift
+++ b/PushExtensionSources/PushLogger.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Internal logger for the AppAmbit Push SDK.
+public class PushLogger {
+
+    public nonisolated(unsafe) static var debugMode = false
+    private static let tag = "[AppAmbitPushSDK]"
+
+    public static func log(_ message: String) {
+        if debugMode {
+            print("\(tag) \(message)")
+        }
+    }
+
+    public static func error(_ message: String) {
+        print("\(tag) ERROR: \(message)")
+    }
+
+    public static func raw(_ message: String) {
+        if debugMode {
+            print(message)
+        }
+    }
+}

--- a/PushExtensionSources/PushNotificationAttachments.swift
+++ b/PushExtensionSources/PushNotificationAttachments.swift
@@ -1,0 +1,52 @@
+import Foundation
+import UserNotifications
+
+/// Helper for handling notification attachments.
+public enum PushNotificationAttachments {
+
+    public static func loadImageAttachment(from urlString: String,
+                                           completion: @escaping (UNNotificationAttachment?) -> Void) {
+        guard let url = URL(string: urlString) else {
+            completion(nil)
+            return
+        }
+
+        let task = URLSession.shared.downloadTask(with: url) { tempUrl, _, error in
+            guard let tempUrl, error == nil else {
+                NSLog("[AppAmbitPushSDK] Download failed: %@", error?.localizedDescription ?? "Invalid URL")
+                completion(nil)
+                return
+            }
+
+            let ext = url.pathExtension.isEmpty ? "tmp" : url.pathExtension
+            let localUrl = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension(ext)
+
+            do {
+                try FileManager.default.moveItem(at: tempUrl, to: localUrl)
+                let attachment = try UNNotificationAttachment(
+                    identifier: "image",
+                    url: localUrl,
+                    options: nil
+                )
+                completion(attachment)
+            } catch {
+                NSLog("[AppAmbitPushSDK] Attachment failed: %@", error.localizedDescription)
+                completion(nil)
+            }
+        }
+
+        task.resume()
+    }
+
+    public static func loadImageAttachment(for notification: AppAmbitNotification,
+                                           completion: @escaping (UNNotificationAttachment?) -> Void) {
+        guard let urlString = notification.imageUrl, !urlString.isEmpty else {
+            completion(nil)
+            return
+        }
+
+        loadImageAttachment(from: urlString, completion: completion)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Lightweight SDK for analytics, events, logging, crashes, and offline support. Si
 ## Requirements
 
 * iOS 12.0 or newer
-* Xcode 15 or newer
-* Swift 5.7 or newer
+* Xcode 16 or newer
+* Swift 6.0 or newer
 
 ---
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🛠️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [ ] 📚 Documentation Update

## Description

This PR adds Swift Package Manager (SPM) distribution support so developers can install `AppAmbit` and `AppAmbitPushNotifications` directly from Xcode without CocoaPods. Both products are exposed from a single repo URL — developers pick only what they need. CocoaPods distribution is unchanged.

**Files changed:**
- `Package.swift` *(new, repo root)* — declares both `AppAmbit` and `AppAmbitPushNotifications` products with custom source paths. No source file moves needed.
- `.spi.yml` *(new)* — tells Swift Package Index which targets to document when the package is submitted to swiftpackageindex.com.
- `.github/workflows/build-cocoapod.yml` — adds `swift package dump-package` validation step before pod lint to catch broken `Package.swift` before a tag is pushed.

**How developers install via SPM:**
```
https://github.com/AppAmbit/appambit-sdk-ios
```
In Xcode → File → Add Package Dependencies → paste URL → pick `AppAmbit` (core) and/or `AppAmbitPushNotifications` (optional).

## Related Tickets & Documents

- [ID-1661](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1214970221937895)
- Closes #ID-1661

## QA Instructions, Screenshots, Recordings

**Test local (reviewer):**
1. Checkout this branch
2. Run in terminal to validate structure:
   ```bash
   swift package describe
   ```
   Expected: lists both `AppAmbit` and `AppAmbitPushNotifications` with all source files.
3. Open Xcode → **File → Add Package Dependencies…** → **Add Local…** (bottom-left)
4. Navigate to repo root (`appambit-sdk-ios/`) → **Add Package**
5. Verify Xcode shows exactly **two products**: `AppAmbit` and `AppAmbitPushNotifications`
6. Add `AppAmbit` to a test iOS target → build → no errors
7. Add `AppAmbitPushNotifications` to a test iOS target → build → no errors
8. Verify CocoaPods still works: `pod lib lint AppAmbitSdk/AppAmbitSdk.podspec --platforms=ios --allow-warnings`

**After merge — publish to Swift Package Index (one-time):**
1. Push the new tag: `git tag 1.1.1 && git push origin 1.1.1`
2. Go to [https://swiftpackageindex.com/add-a-package](https://swiftpackageindex.com/add-a-package)
3. Log in with the AppAmbit GitHub account
4. Paste: `https://github.com/AppAmbit/appambit-sdk-ios` → Submit
5. SPI indexes within minutes — package appears with iOS 12+ badge, Swift version matrix, and both products listed

## Added/updated tests?

- [ ] ✅ Yes
- [x] ❌ No, and this is why: SPM support is distribution-only. No logic changes. Existing tests in `AppAmbitSdk/` cover the SDK. Run with `swift test --package-path AppAmbitSdk`.
- [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?

- [x] 📝 Yes — after merge and tag, submit repo to [swiftpackageindex.com/add-a-package](https://swiftpackageindex.com/add-a-package) once using the AppAmbit GitHub account.
- [ ] ❌ No
- [ ] ❓ I don't know
