### PR TITLE
ID-1767- Chore: bump to 1.1.1 and document SPM installation to MAIN

### DIFF
--- a/AppAmbitSdk/AppAmbitSdk.podspec
+++ b/AppAmbitSdk/AppAmbitSdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppAmbitSdk'
-  s.version          = '1.1.0'
+  s.version          = '1.1.1'
   s.module_name      = 'AppAmbit'
   s.summary          = 'Lightweight SDK for analytics, events, logging, crashes, and offline support. Simple setup, minimal overhead.'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Version 1.1.1
+
+### AppAmbit
+
+* **[Fix]** Published a release tag that includes the root `Package.swift`, so the SDK can be resolved via Swift Package Manager. The `1.1.0` tag predated the manifest and failed with "the package manifest at '/Package.swift' cannot be accessed".
+
+___
+
 ## Version 1.1.0
 
 ### AppAmbit

--- a/Push/AppAmbitPushNotifications/AppAmbitPushNotifications.podspec
+++ b/Push/AppAmbitPushNotifications/AppAmbitPushNotifications.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "AppAmbitPushNotifications"
-  spec.version      = "1.1.0"
+  spec.version      = "1.1.1"
   spec.summary      = "Push Notifications SDK for iOS to send push notifications via AppAmbit platform."
 
   spec.description  = <<-DESC

--- a/Push/AppAmbitPushNotifications/AppAmbitPushNotificationsExtension.podspec
+++ b/Push/AppAmbitPushNotifications/AppAmbitPushNotificationsExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name         = "AppAmbitPushNotificationsExtension"
-  spec.version      = "1.1.0"
+  spec.version      = "1.1.1"
   spec.summary      = "Extension-safe slice of AppAmbitPushNotifications for iOS Notification Service Extensions."
 
   spec.description  = <<-DESC

--- a/Push/AppAmbitPushNotifications/README.md
+++ b/Push/AppAmbitPushNotifications/README.md
@@ -19,8 +19,54 @@ Complete push notifications SDK for iOS that integrates seamlessly with the AppA
 
 ### Swift Package Manager
 
-* Add the repository URL in Xcode under **File → Add Packages…**
-* Select the latest version and attach it to your app target
+> Requires **1.1.1 or newer**. Earlier tags do not ship a package manifest and cannot be resolved by SPM.
+
+Push notifications ship as part of the main SDK package, so you add the same repository and pick the products you need.
+
+#### In Xcode
+
+1. Go to **File → Add Package Dependencies…**
+2. Paste the repository URL into the search field:
+
+   ```
+   https://github.com/AppAmbit/appambit-sdk-ios
+   ```
+
+3. Set **Dependency Rule** to **Up to Next Major Version** starting at `1.1.1`.
+4. Click **Add Package**, then attach each product to the target that needs it:
+
+| Product | Add to target | Import |
+|---|---|---|
+| `AppAmbit` | Your app | `import AppAmbit` |
+| `AppAmbitPushNotifications` | Your app, and your Notification Service Extension | `import AppAmbitPushNotifications` |
+| `AppAmbitPushNotificationsExtension` | Your Notification Service Extension *(alternative — see below)* | `import AppAmbitPushNotificationsExtension` |
+
+`AppAmbitPushNotifications` already contains everything a Notification Service Extension needs, so linking it to both targets works and is what the sample apps do.
+
+`AppAmbitPushNotificationsExtension` is an optional, extension-safe slice: it provides the same `AppAmbitNotificationService`, `AppAmbitNotificationProcessor`, `AppAmbitNotification` and `PushNotificationAttachments`, but depends only on Foundation and UserNotifications and does not pull in the main SDK. Use it if you prefer to keep app-only code out of the extension. If you do, import `AppAmbitPushNotificationsExtension` instead of `AppAmbitPushNotifications` in that target.
+
+#### In a `Package.swift`
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/AppAmbit/appambit-sdk-ios", from: "1.1.1")
+],
+targets: [
+    .target(
+        name: "YourApp",
+        dependencies: [
+            .product(name: "AppAmbit", package: "appambit-sdk-ios"),
+            .product(name: "AppAmbitPushNotifications", package: "appambit-sdk-ios")
+        ]
+    ),
+    .target(
+        name: "YourNotificationServiceExtension",
+        dependencies: [
+            .product(name: "AppAmbitPushNotificationsExtension", package: "appambit-sdk-ios")
+        ]
+    )
+]
+```
 
 ### CocoaPods
 
@@ -29,7 +75,7 @@ Add this to your Podfile:
 ```ruby
 pod 'AppAmbitPushNotifications'
 # or specify version
-pod 'AppAmbitPushNotifications', '~> 1.1.0'
+pod 'AppAmbitPushNotifications', '~> 1.1.1'
 ```
 
 Then run:
@@ -122,6 +168,10 @@ PushNotifications.requestNotificationPermission { granted in
 1. In Xcode: **File > New > Target > Notification Service Extension**
 2. Add `AppAmbitPushNotifications` to the **extension target** (not just the app target).
 3. Embed the extension in your app target: **App target > General > Frameworks, Libraries, and Embedded Content > +** and add the `.appex`.
+
+> Optionally, link `AppAmbitPushNotificationsExtension` to the extension instead — the
+> extension-safe slice described in [Install](#swift-package-manager). It exposes the same
+> types, so the examples below are unchanged apart from the module you import.
 
 #### Swift extension — subclass `AppAmbitNotificationService`
 

--- a/Push/AppAmbitPushNotifications/README.md
+++ b/Push/AppAmbitPushNotifications/README.md
@@ -19,7 +19,7 @@ Complete push notifications SDK for iOS that integrates seamlessly with the AppA
 
 ### Swift Package Manager
 
-> Requires **1.1.1 or newer**. Earlier tags do not ship a package manifest and cannot be resolved by SPM.
+> Requires **v1.1.1 or newer**. Earlier tags do not ship a package manifest and cannot be resolved by SPM.
 
 Push notifications ship as part of the main SDK package, so you add the same repository and pick the products you need.
 
@@ -32,7 +32,7 @@ Push notifications ship as part of the main SDK package, so you add the same rep
    https://github.com/AppAmbit/appambit-sdk-ios
    ```
 
-3. Set **Dependency Rule** to **Up to Next Major Version** starting at `1.1.1`.
+3. Set **Dependency Rule** to **Up to Next Major Version** starting at `v1.1.1`.
 4. Click **Add Package**, then attach each product to the target that needs it:
 
 | Product | Add to target | Import |

--- a/README.md
+++ b/README.md
@@ -53,8 +53,43 @@ Lightweight SDK for analytics, events, logging, crashes, and offline support. Si
 
 ### Swift Package Manager
 
-* Add the repository URL in Xcode under **File → Add Packages…**
-* Select the latest version and attach it to your app target
+> Requires **1.1.1 or newer**. Earlier tags do not ship a package manifest and cannot be resolved by SPM.
+
+#### In Xcode
+
+1. Go to **File → Add Package Dependencies…**
+2. Paste the repository URL into the search field:
+
+   ```
+   https://github.com/AppAmbit/appambit-sdk-ios
+   ```
+
+3. Set **Dependency Rule** to **Up to Next Major Version** starting at `1.1.1`.
+4. Click **Add Package**, then attach each product to the target that needs it:
+
+| Product | Add to target | Import |
+|---|---|---|
+| `AppAmbit` | Your app | `import AppAmbit` |
+| `AppAmbitPushNotifications` | Your app *(optional — only if you use push)* | `import AppAmbitPushNotifications` |
+| `AppAmbitPushNotificationsExtension` | Your Notification Service Extension *(optional)* | `import AppAmbitPushNotificationsExtension` |
+
+Most apps only need `AppAmbit`. See the [Push Notifications guide](Push/AppAmbitPushNotifications/README.md) for the other two.
+
+#### In a `Package.swift`
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/AppAmbit/appambit-sdk-ios", from: "1.1.1")
+],
+targets: [
+    .target(
+        name: "YourApp",
+        dependencies: [
+            .product(name: "AppAmbit", package: "appambit-sdk-ios")
+        ]
+    )
+]
+```
 
 ### CocoaPods
 
@@ -63,7 +98,7 @@ Add this to your Podfile:
 ```ruby
 pod 'AppAmbitSdk'
 # or specify version
-pod 'AppAmbitSdk', '~> 1.1.0'
+pod 'AppAmbitSdk', '~> 1.1.1'
 ```
 
 Then run:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Lightweight SDK for analytics, events, logging, crashes, and offline support. Si
 
 ### Swift Package Manager
 
-> Requires **1.1.1 or newer**. Earlier tags do not ship a package manifest and cannot be resolved by SPM.
+> Requires *v1.1.1 or newer**. Earlier tags do not ship a package manifest and cannot be resolved by SPM.
 
 #### In Xcode
 
@@ -64,7 +64,7 @@ Lightweight SDK for analytics, events, logging, crashes, and offline support. Si
    https://github.com/AppAmbit/appambit-sdk-ios
    ```
 
-3. Set **Dependency Rule** to **Up to Next Major Version** starting at `1.1.1`.
+3. Set **Dependency Rule** to **Up to Next Major Version** starting at `v1.1.1`.
 4. Click **Add Package**, then attach each product to the target that needs it:
 
 | Product | Add to target | Import |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Lightweight SDK for analytics, events, logging, crashes, and offline support. Si
 
 ### Swift Package Manager
 
-> Requires *v1.1.1 or newer**. Earlier tags do not ship a package manifest and cannot be resolved by SPM.
+> Requires *v1.1.1 or newer*. Earlier tags do not ship a package manifest and cannot be resolved by SPM.
 
 #### In Xcode
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Lightweight SDK for analytics, events, logging, crashes, and offline support. Si
 
 ### Swift Package Manager
 
-> Requires *v1.1.1 or newer*. Earlier tags do not ship a package manifest and cannot be resolved by SPM.
+> Requires **v1.1.1 or newer**. Earlier tags do not ship a package manifest and cannot be resolved by SPM.
 
 #### In Xcode
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] ✨ Feature
- [ ] 🛠️ Refactor
- [x] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [x] 📚 Documentation Update

## Related Tickets & Documents

- [ID-1767](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1217280680359758)
- Closes #ID-1767

---

## Description

Installing the SDK through Swift Package Manager fails with:

```
the package manifest at '/Package.swift' cannot be accessed (/Package.swift doesn't exist in file system)
```

The manifest itself is fine. The problem is the tag: `1.1.0` points at `4984b8c`, a commit that predates the root `Package.swift` (added in `bf701d1`, merged in `205fd86`). SPM resolves the tag, not the branch, so it checks out a tree where the manifest does not exist.

Since SPM derives versions from git tags, the fix is to publish a tag on a commit that does contain the manifest. The release workflow skips tags that already exist, so `1.1.0` cannot be re-cut — this bumps to `1.1.1`.

No SDK source code changes. Version bump, changelog entry, and SPM installation docs only.

## Version 1.1.1

### AppAmbit

* **[Fix]** Published a release tag that includes the root `Package.swift`, so the SDK can be resolved via Swift Package Manager. The `1.1.0` tag predated the manifest and failed with "the package manifest at '/Package.swift' cannot be accessed".

### Changes

* Bumped `1.1.0` → `1.1.1` in the three podspecs (`AppAmbitSdk`, `AppAmbitPushNotifications`, `AppAmbitPushNotificationsExtension`).
* Added the `1.1.1` section to `CHANGELOG.md`.
* Rewrote the **Swift Package Manager** install sections in `README.md` and `Push/AppAmbitPushNotifications/README.md`: repository URL, dependency rule, a product → target → import table, and a `Package.swift` snippet.
* Bumped the pinned Podfile examples in both READMEs from `~> 1.1.0` to `~> 1.1.1`.
* Documented `AppAmbitPushNotificationsExtension` as an optional, extension-safe alternative for Notification Service Extension targets. The default path and every code snippet still use `AppAmbitPushNotifications`, unchanged — no action required from existing integrations.

## Added/updated tests?

- [ ] ✅ Yes
- [x] ❌ No, and this is why: is a release
- [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?
- [x] 📝 Yes (please add details)
- [ ] ❌ No
- [ ] ❓ I don't know