### PR TITLE
ID-1768 - Add Cloud Code support to the iOS SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ fastlane/screenshots/**/*.png
 fastlane/test_output
 .DS_Store
 CLAUDE.md
+build

--- a/AppAmbit.xcodeproj/project.pbxproj
+++ b/AppAmbit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1388B6EE0A134AFCB0F32F3E /* Samples/AppAmbit.App.Swift/CloudCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E90F6A8CC44479B7CCA237 /* Samples/AppAmbit.App.Swift/CloudCodeView.swift */; };
 		7916DAD32E171C9B00CFEFA2 /* AppAmbit in Frameworks */ = {isa = PBXBuildFile; productRef = 7916DAD22E171C9B00CFEFA2 /* AppAmbit */; };
 		7928260C2FAEAB8C00766B64 /* AppAmbitPushNotifications in Frameworks */ = {isa = PBXBuildFile; productRef = 7928260B2FAEAB8C00766B64 /* AppAmbitPushNotifications */; };
 		7928260D2FAEAB8C00766B64 /* AppAmbitPushNotifications in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 7928260B2FAEAB8C00766B64 /* AppAmbitPushNotifications */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -126,6 +127,7 @@
 		792825FE2FAEA6AD00766B64 /* NotificationServiceObjC.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationServiceObjC.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		79712D1C2E7CD50D00B99DB6 /* AppAmbit.App.ObjC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AppAmbit.App.ObjC.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		797B71692F1050260032E3ED /* NotificationServiceSwift.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationServiceSwift.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		C6E90F6A8CC44479B7CCA237 /* Samples/AppAmbit.App.Swift/CloudCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Samples/AppAmbit.App.Swift/CloudCodeView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -149,12 +151,15 @@
 				AppAmbit.App.Swift/AnalyticsView.swift,
 				AppAmbit.App.Swift/AppAmbitTestingApp.swift,
 				AppAmbit.App.Swift/Assets.xcassets,
+				AppAmbit.App.Swift/CloudCodeView.swift,
 				AppAmbit.App.Swift/CmsView.swift,
 				AppAmbit.App.Swift/ContentView.swift,
 				AppAmbit.App.Swift/CrashesView.swift,
 				AppAmbit.App.Swift/DatabaseView.swift,
 				AppAmbit.App.Swift/LoadView.swift,
+				AppAmbit.App.Swift/models/CloudCodeDemo.swift,
 				AppAmbit.App.Swift/models/CmsExampleModel.swift,
+				AppAmbit.App.Swift/models/DashboardSummary.swift,
 				"AppAmbit.App.Swift/Preview Content/Preview Assets.xcassets",
 				AppAmbit.App.Swift/RemoteConfigView.swift,
 				AppAmbit.App.Swift/SecondView.swift,
@@ -172,12 +177,15 @@
 				AppAmbit.App.Swift/AnalyticsView.swift,
 				AppAmbit.App.Swift/AppAmbitTestingApp.swift,
 				AppAmbit.App.Swift/Assets.xcassets,
+				AppAmbit.App.Swift/CloudCodeView.swift,
 				AppAmbit.App.Swift/CmsView.swift,
 				AppAmbit.App.Swift/ContentView.swift,
 				AppAmbit.App.Swift/CrashesView.swift,
 				AppAmbit.App.Swift/DatabaseView.swift,
 				AppAmbit.App.Swift/LoadView.swift,
+				AppAmbit.App.Swift/models/CloudCodeDemo.swift,
 				AppAmbit.App.Swift/models/CmsExampleModel.swift,
+				AppAmbit.App.Swift/models/DashboardSummary.swift,
 				"AppAmbit.App.Swift/Preview Content/Preview Assets.xcassets",
 				AppAmbit.App.Swift/RemoteConfigView.swift,
 				AppAmbit.App.Swift/SecondView.swift,
@@ -280,6 +288,7 @@
 				7916DAB22E1719AF00CFEFA2 /* Frameworks */,
 				79260B8D2E139E23008BF6CB /* Products */,
 				791D978D2EEA0506002FC398 /* AppAmbitSdk */,
+				79768E1C302CDD67008CA0D1 /* Recovered References */,
 			);
 			sourceTree = "<group>";
 		};
@@ -292,6 +301,14 @@
 				792825FE2FAEA6AD00766B64 /* NotificationServiceObjC.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		79768E1C302CDD67008CA0D1 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				C6E90F6A8CC44479B7CCA237 /* Samples/AppAmbit.App.Swift/CloudCodeView.swift */,
+			);
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -485,6 +502,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1388B6EE0A134AFCB0F32F3E /* Samples/AppAmbit.App.Swift/CloudCodeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AppAmbitSdk/AppAmbitSdk.podspec
+++ b/AppAmbitSdk/AppAmbitSdk.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppAmbitSdk'
-  s.version          = '1.1.2'
+  s.version          = '1.2.0'
   s.module_name      = 'AppAmbit'
   s.summary          = 'Lightweight SDK for analytics, events, logging, crashes, and offline support. Simple setup, minimal overhead.'
 

--- a/AppAmbitSdk/Sources/AppAmbit.swift
+++ b/AppAmbitSdk/Sources/AppAmbit.swift
@@ -178,6 +178,7 @@ public final class AppAmbit: NSObject, @unchecked Sendable {
         Logging.initialize(apiService: apiService, storageService: storageService)
         Cms.initialize(apiService: apiService)
         AppAmbitDb.initialize(dbService: ServiceContainer.shared.dbService)
+        CloudCode.initialize(service: ServiceContainer.shared.cloudCodeService)
 
         self.reachability = reachabilityService
 

--- a/AppAmbitSdk/Sources/AppConstants.swift
+++ b/AppAmbitSdk/Sources/AppConstants.swift
@@ -11,6 +11,7 @@ class AppConstants {
     static let trackEventMaxPropertyLimit = 20;
     static let trackEventPropertyMaxCharacters = 80;
     static let liveSessionStreaming = "live_session_streaming"
+    static let networkTimeout: TimeInterval = 20
     static let cloudCodeTimeout: TimeInterval = 60
     static let baseUrlSdk = "https://appambit.com/api"
     static let baseUrlCms = "https://cms.appambit.com/api/v1"

--- a/AppAmbitSdk/Sources/AppConstants.swift
+++ b/AppAmbitSdk/Sources/AppConstants.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 class AppConstants {
     static let databaseFileName = "AppAmbit"
     static let noStackTraceAvailable = "NoStackTraceAvailable";
@@ -9,6 +11,7 @@ class AppConstants {
     static let trackEventMaxPropertyLimit = 20;
     static let trackEventPropertyMaxCharacters = 80;
     static let liveSessionStreaming = "live_session_streaming"
+    static let cloudCodeTimeout: TimeInterval = 60
     static let baseUrlSdk = "https://appambit.com/api"
     static let baseUrlCms = "https://cms.appambit.com/api/v1"
 }

--- a/AppAmbitSdk/Sources/CloudCode.swift
+++ b/AppAmbitSdk/Sources/CloudCode.swift
@@ -30,7 +30,9 @@ public final class CloudCode: NSObject {
     ) -> CloudCodeCancellationToken {
         guard let service = currentService() else {
             let token = CloudCodeCancellationToken()
-            completion(nil, CloudCodeError.notInitialized)
+            DispatchQueue.main.async {
+                completion(nil, CloudCodeError.notInitialized)
+            }
             return token
         }
         return service.call(
@@ -56,7 +58,9 @@ public final class CloudCode: NSObject {
     ) -> CloudCodeCancellationToken {
         guard let service = currentService() else {
             let token = CloudCodeCancellationToken()
-            completion(nil, CloudCodeError.notInitialized)
+            DispatchQueue.main.async {
+                completion(nil, CloudCodeError.notInitialized)
+            }
             return token
         }
         return service.call(

--- a/AppAmbitSdk/Sources/CloudCode.swift
+++ b/AppAmbitSdk/Sources/CloudCode.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+@objcMembers
+public final class CloudCode: NSObject {
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var service: CloudCodeService?
+
+    static func initialize(service: CloudCodeService) {
+        lock.lock()
+        self.service = service
+        lock.unlock()
+    }
+
+    #if DEBUG
+    static func resetForTesting() {
+        lock.lock()
+        service = nil
+        lock.unlock()
+    }
+    #endif
+
+    @discardableResult
+    public static func call(
+        _ function: String,
+        method: CloudCodeHttpMethod = .post,
+        query: [String: String]? = nil,
+        body: [String: Any]? = nil,
+        headers: [String: String]? = nil,
+        completion: @escaping @Sendable (CloudCodeResponse?, Error?) -> Void
+    ) -> CloudCodeCancellationToken {
+        guard let service = currentService() else {
+            let token = CloudCodeCancellationToken()
+            completion(nil, CloudCodeError.notInitialized)
+            return token
+        }
+        return service.call(
+            function: function,
+            method: method,
+            query: query,
+            body: body,
+            headers: headers,
+            completion: completion
+        )
+    }
+
+    @nonobjc
+    @discardableResult
+    public static func call<T: Decodable>(
+        _ function: String,
+        method: CloudCodeHttpMethod = .post,
+        query: [String: String]? = nil,
+        body: [String: Any]? = nil,
+        headers: [String: String]? = nil,
+        as type: T.Type,
+        completion: @escaping @Sendable (CloudCodeResult<T>?, CloudCodeError?) -> Void
+    ) -> CloudCodeCancellationToken {
+        guard let service = currentService() else {
+            let token = CloudCodeCancellationToken()
+            completion(nil, CloudCodeError.notInitialized)
+            return token
+        }
+        return service.call(
+            function: function,
+            method: method,
+            query: query,
+            body: body,
+            headers: headers,
+            as: type,
+            completion: completion
+        )
+    }
+
+    private static func currentService() -> CloudCodeService? {
+        lock.lock()
+        defer { lock.unlock() }
+        return service
+    }
+}

--- a/AppAmbitSdk/Sources/Enums/CloudCodeError.swift
+++ b/AppAmbitSdk/Sources/Enums/CloudCodeError.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+public enum CloudCodeError: Error, LocalizedError, Equatable, @unchecked Sendable {
+    case notInitialized
+    case invalidFunction(String)
+    case invalidBody
+    case invalidHeader(String)
+    case networkUnavailable
+    case timedOut
+    case invalidURL
+    case transport(String)
+    case decoding(String)
+    case http(statusCode: Int, body: JSONValue?, rawBody: String?, requestId: String?)
+
+    public var errorDescription: String? {
+        switch self {
+        case .notInitialized:
+            return "Cloud Code is not initialized. Call AppAmbit.start() first."
+        case .invalidFunction(let function):
+            return "Invalid Cloud Code function slug: \(function)"
+        case .invalidBody:
+            return "The Cloud Code body is not valid JSON."
+        case .invalidHeader(let header):
+            return "The Cloud Code header is reserved and cannot be overridden: \(header)"
+        case .networkUnavailable:
+            return "Cloud Code is unavailable because the network is offline."
+        case .timedOut:
+            return "Cloud Code request timed out."
+        case .invalidURL:
+            return "Cloud Code URL is invalid."
+        case .transport(let message):
+            return "Cloud Code network request failed: \(message)"
+        case .decoding(let message):
+            return "Cloud Code response could not be decoded: \(message)"
+        case .http(let statusCode, _, let rawBody, let requestId):
+            var message = "Cloud Code returned HTTP \(statusCode)."
+            if let rawBody, !rawBody.isEmpty {
+                message += " Body: \(rawBody)"
+            }
+            if let requestId {
+                message += " Request ID: \(requestId)"
+            }
+            return message
+        }
+    }
+}

--- a/AppAmbitSdk/Sources/Enums/CloudCodeError.swift
+++ b/AppAmbitSdk/Sources/Enums/CloudCodeError.swift
@@ -1,6 +1,14 @@
 import Foundation
 
-public enum CloudCodeError: Error, LocalizedError, Equatable, @unchecked Sendable {
+@objcMembers
+public final class CloudCodeErrorKeys: NSObject {
+    public static let statusCode = "CloudCodeErrorStatusCodeKey"
+    public static let body = "CloudCodeErrorBodyKey"
+    public static let rawBody = "CloudCodeErrorRawBodyKey"
+    public static let requestId = "CloudCodeErrorRequestIdKey"
+}
+
+public enum CloudCodeError: Error, LocalizedError, CustomNSError, Equatable, @unchecked Sendable {
     case notInitialized
     case invalidFunction(String)
     case invalidBody
@@ -11,6 +19,34 @@ public enum CloudCodeError: Error, LocalizedError, Equatable, @unchecked Sendabl
     case transport(String)
     case decoding(String)
     case http(statusCode: Int, body: JSONValue?, rawBody: String?, requestId: String?)
+
+    public static let errorDomain = "com.appambit.cloud-code"
+
+    public var errorCode: Int {
+        switch self {
+        case .notInitialized: return 1
+        case .invalidFunction: return 2
+        case .invalidBody: return 3
+        case .invalidHeader: return 4
+        case .networkUnavailable: return 5
+        case .timedOut: return 6
+        case .invalidURL: return 7
+        case .transport: return 8
+        case .decoding: return 9
+        case .http: return 10
+        }
+    }
+
+    public var errorUserInfo: [String: Any] {
+        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: errorDescription ?? "Cloud Code error"]
+        if case .http(let statusCode, let body, let rawBody, let requestId) = self {
+            userInfo[CloudCodeErrorKeys.statusCode] = statusCode
+            if let body { userInfo[CloudCodeErrorKeys.body] = body.toAny() }
+            if let rawBody { userInfo[CloudCodeErrorKeys.rawBody] = rawBody }
+            if let requestId { userInfo[CloudCodeErrorKeys.requestId] = requestId }
+        }
+        return userInfo
+    }
 
     public var errorDescription: String? {
         switch self {

--- a/AppAmbitSdk/Sources/Enums/CloudCodeHttpMethod.swift
+++ b/AppAmbitSdk/Sources/Enums/CloudCodeHttpMethod.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+@objc public enum CloudCodeHttpMethod: Int {
+    case get
+    case post
+    case put
+    case patch
+    case delete
+
+    var apiMethod: HttpMethodApp {
+        switch self {
+        case .get: return .get
+        case .post: return .post
+        case .put: return .put
+        case .patch: return .patch
+        case .delete: return .delete
+        }
+    }
+}

--- a/AppAmbitSdk/Sources/Models/CloudCodeCancellationToken.swift
+++ b/AppAmbitSdk/Sources/Models/CloudCodeCancellationToken.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+@objcMembers
+public final class CloudCodeCancellationToken: NSObject, @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+
+    public func cancel() {
+        lock.lock()
+        cancelled = true
+        lock.unlock()
+    }
+
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+}

--- a/AppAmbitSdk/Sources/Models/CloudCodeResponse.swift
+++ b/AppAmbitSdk/Sources/Models/CloudCodeResponse.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public struct CloudCodeResult<T: Decodable>: @unchecked Sendable {
+    public let data: T
+    public let statusCode: Int
+    public let requestId: String?
+
+    public init(data: T, statusCode: Int, requestId: String?) {
+        self.data = data
+        self.statusCode = statusCode
+        self.requestId = requestId
+    }
+}
+
+@objcMembers
+public final class CloudCodeResponse: NSObject, @unchecked Sendable {
+    public let data: Any
+    public let statusCode: Int
+    public let requestId: String?
+
+    public init(data: Any, statusCode: Int, requestId: String?) {
+        self.data = data
+        self.statusCode = statusCode
+        self.requestId = requestId
+    }
+}

--- a/AppAmbitSdk/Sources/Models/CloudCodeResponse.swift
+++ b/AppAmbitSdk/Sources/Models/CloudCodeResponse.swift
@@ -4,11 +4,18 @@ public struct CloudCodeResult<T: Decodable>: @unchecked Sendable {
     public let data: T
     public let statusCode: Int
     public let requestId: String?
+    public let headers: [String: String]
 
-    public init(data: T, statusCode: Int, requestId: String?) {
+    public init(
+        data: T,
+        statusCode: Int,
+        requestId: String?,
+        headers: [String: String] = [:]
+    ) {
         self.data = data
         self.statusCode = statusCode
         self.requestId = requestId
+        self.headers = headers
     }
 }
 
@@ -17,10 +24,17 @@ public final class CloudCodeResponse: NSObject, @unchecked Sendable {
     public let data: Any
     public let statusCode: Int
     public let requestId: String?
+    public let headers: [String: String]
 
-    public init(data: Any, statusCode: Int, requestId: String?) {
+    public init(
+        data: Any,
+        statusCode: Int,
+        requestId: String?,
+        headers: [String: String] = [:]
+    ) {
         self.data = data
         self.statusCode = statusCode
         self.requestId = requestId
+        self.headers = headers
     }
 }

--- a/AppAmbitSdk/Sources/Models/CloudCodeResponse.swift
+++ b/AppAmbitSdk/Sources/Models/CloudCodeResponse.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 public struct CloudCodeResult<T: Decodable>: @unchecked Sendable {
-    public let data: T
+    public let data: T?
     public let statusCode: Int
     public let requestId: String?
     public let headers: [String: String]
 
     public init(
-        data: T,
+        data: T?,
         statusCode: Int,
         requestId: String?,
         headers: [String: String] = [:]

--- a/AppAmbitSdk/Sources/ServiceContainer.swift
+++ b/AppAmbitSdk/Sources/ServiceContainer.swift
@@ -6,6 +6,7 @@ final class ServiceContainer {
     let storageService: StorageService
     let reachabilityService: ReachabilityService
     let dbService: DbService
+    let cloudCodeService: CloudCodeService
 
     private nonisolated(unsafe) static let _instance: ServiceContainer = {
         let dataStore: DataStore
@@ -37,7 +38,8 @@ final class ServiceContainer {
             appInfoService: AppAmbitInfoService(),
             storageService: storageService,
             reachabilityService: reachabilityService,
-            dbService: DbService(apiService: apiService)
+            dbService: DbService(apiService: apiService),
+            cloudCodeService: CloudCodeService(transport: apiService)
         )
     }()
 
@@ -57,12 +59,14 @@ final class ServiceContainer {
         appInfoService: AppInfoService,
         storageService: StorageService,
         reachabilityService: ReachabilityService,
-        dbService: DbService
+        dbService: DbService,
+        cloudCodeService: CloudCodeService
     ) {
         self.apiService = apiService
         self.appInfoService = appInfoService
         self.storageService = storageService
         self.reachabilityService = reachabilityService
         self.dbService = dbService
+        self.cloudCodeService = cloudCodeService
     }
 }

--- a/AppAmbitSdk/Sources/Services/AppAmbitApiService.swift
+++ b/AppAmbitSdk/Sources/Services/AppAmbitApiService.swift
@@ -14,12 +14,16 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
     // MARK: - Networking
 
     private let urlSession: URLSession
+    private let cloudCodeSession: URLSession
     private let isConnected: @Sendable () -> Bool
 
-    private static func makeURLSession() -> URLSession {
+    private static func makeURLSession(
+        requestTimeout: TimeInterval,
+        resourceTimeout: TimeInterval
+    ) -> URLSession {
         let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 20
-        config.timeoutIntervalForResource = AppConstants.cloudCodeTimeout
+        config.timeoutIntervalForRequest = requestTimeout
+        config.timeoutIntervalForResource = resourceTimeout
         config.waitsForConnectivity = true
         config.httpMaximumConnectionsPerHost = 2
         return URLSession(configuration: config)
@@ -30,10 +34,19 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
     init(
         storageService: StorageService,
         urlSession: URLSession? = nil,
+        cloudCodeSession: URLSession? = nil,
         isConnected: @escaping @Sendable () -> Bool = { ServiceContainer.shared.reachabilityService.isConnected() }
     ) {
         self.storageService = storageService
-        self.urlSession = urlSession ?? Self.makeURLSession()
+        let configuredURLSession = urlSession ?? Self.makeURLSession(
+            requestTimeout: AppConstants.networkTimeout,
+            resourceTimeout: AppConstants.networkTimeout
+        )
+        self.urlSession = configuredURLSession
+        self.cloudCodeSession = cloudCodeSession ?? urlSession ?? Self.makeURLSession(
+            requestTimeout: AppConstants.cloudCodeTimeout,
+            resourceTimeout: AppConstants.cloudCodeTimeout
+        )
         self.isConnected = isConnected
     }
 
@@ -144,7 +157,7 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
         Queues.state.async { [weak self] in
             guard let self else { return }
 
-            TokenService.createTokenEndpoint { [weak self] result in
+            TokenService.createTokenEndpoint(storageService: self.storageService) { [weak self] result in
                 guard let self else { return }
                 switch result {
                 case .success(let endpoint):
@@ -325,8 +338,12 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
             return
         }
 
-        let queryItems = URLQueryBuilder.queryItems(from: dictionary)
-        urlComponents.queryItems = queryItems.isEmpty ? nil : queryItems
+        let query = URLQueryBuilder.percentEncodedQuery(from: dictionary)
+        guard !query.isEmpty else { return }
+        urlComponents.percentEncodedQuery = [urlComponents.percentEncodedQuery, query]
+            .compactMap { $0 }
+            .filter { !$0.isEmpty }
+            .joined(separator: "&")
         guard let urlWithQueryParams = urlComponents.url else {
             throw ApiExceptions.invalidURL
         }
@@ -360,7 +377,7 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
         responseType: T.Type,
         completion: @escaping @Sendable (ApiResult<T>) -> Void
     ) {
-        urlSession.dataTask(with: request) { [weak self] data, response, error in
+        cloudCodeSession.dataTask(with: request) { [weak self] data, response, error in
             guard let self else { return }
 
             Queues.netDecode.async {

--- a/AppAmbitSdk/Sources/Services/AppAmbitApiService.swift
+++ b/AppAmbitSdk/Sources/Services/AppAmbitApiService.swift
@@ -24,7 +24,7 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
 
     private lazy var cloudCodeSession: URLSession = {
         let config = URLSessionConfiguration.default
-        config.timeoutIntervalForResource = 120
+        config.timeoutIntervalForResource = 80
         config.waitsForConnectivity = true
         config.httpMaximumConnectionsPerHost = 2
         return URLSession(configuration: config)

--- a/AppAmbitSdk/Sources/Services/AppAmbitApiService.swift
+++ b/AppAmbitSdk/Sources/Services/AppAmbitApiService.swift
@@ -22,6 +22,14 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
         return URLSession(configuration: config)
     }()
 
+    private lazy var cloudCodeSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForResource = 120
+        config.waitsForConnectivity = true
+        config.httpMaximumConnectionsPerHost = 2
+        return URLSession(configuration: config)
+    }()
+
     // MARK: - Init
 
     init(storageService: StorageService) {
@@ -142,21 +150,34 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
     // MARK: - Refresh token
 
     private func handleTokenRefresh<T: Decodable>(
-        originalRequest: URLRequest?,
+        originalRequest: URLRequest,
         skipAuth: Bool,
         responseType: T.Type,
         completion: @escaping @Sendable (ApiResult<T>) -> Void
     ) {
-        let retryAction: (ApiErrorType) -> Void = { [weak self] error in
+        let retryAction: () -> Void = { [weak self] in
             guard let self else { return }
-            if error == .none, let originalRequest {
-                var newRequest = originalRequest
-                if !skipAuth, let token = self.token {
-                    newRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-                }
-                self.processResponse(request: newRequest, responseType: responseType, completion: completion)
+            var newRequest = originalRequest
+            if !skipAuth, let token = self.token {
+                newRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            }
+            self.processResponse(request: newRequest, responseType: responseType, completion: completion)
+        }
+
+        refreshTokenAndRetryRequests(retry: retryAction) { error in
+            completion(.fail(error, message: "Token renewal failure"))
+        }
+    }
+
+    private func refreshTokenAndRetryRequests(
+        retry: @escaping () -> Void,
+        failure: @escaping (ApiErrorType) -> Void
+    ) {
+        let retryAction: (ApiErrorType) -> Void = { error in
+            if error == .none {
+                retry()
             } else {
-                completion(.fail(error, message: "Token renewal failure"))
+                failure(error)
             }
         }
 
@@ -555,4 +576,109 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
         }
         return result
     }
+
+    func executeCloudCodeRequest(
+        _ endpoint: CloudCodeEndpoint,
+        timeout: TimeInterval,
+        completion: @escaping @Sendable (CloudCodeTransportResponse) -> Void
+    ) {
+        performCloudCodeRequest(endpoint, timeout: timeout) { [weak self] response in
+            guard let self else { return }
+            guard response.statusCode == 401 else {
+                completion(response)
+                return
+            }
+
+            self.refreshTokenAndRetryRequests(retry: {
+                [weak self] in
+                guard let self else { return }
+                self.performCloudCodeRequest(endpoint, timeout: timeout, completion: completion)
+            }) { _ in
+                completion(CloudCodeTransportResponse(
+                    statusCode: 401,
+                    data: response.data,
+                    headers: response.headers,
+                    error: nil
+                ))
+            }
+        }
+    }
+
+    private func performCloudCodeRequest(
+        _ endpoint: CloudCodeEndpoint,
+        timeout: TimeInterval,
+        completion: @escaping @Sendable (CloudCodeTransportResponse) -> Void
+    ) {
+        Queues.state.async { [weak self] in
+            guard let self else { return }
+
+            guard ServiceContainer.shared.reachabilityService.isConnected() else {
+                completion(CloudCodeTransportResponse(
+                    statusCode: nil,
+                    data: nil,
+                    headers: [:],
+                    error: URLError(.notConnectedToInternet)
+                ))
+                return
+            }
+
+            guard let url = URL(string: endpoint.baseUrl + endpoint.url) else {
+                completion(CloudCodeTransportResponse(
+                    statusCode: nil,
+                    data: nil,
+                    headers: [:],
+                    error: ApiExceptions.invalidURL
+                ))
+                return
+            }
+
+            var request = URLRequest(url: url)
+            request.httpMethod = endpoint.method.stringValue
+            request.timeoutInterval = timeout
+
+            if let customHeaders = endpoint.customHeader {
+                for (key, value) in customHeaders {
+                    request.setValue(value, forHTTPHeaderField: key)
+                }
+            }
+
+            request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+            if let token = self.token {
+                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            }
+
+            if let body = endpoint.payload as? [String: Any] {
+                do {
+                    request.httpBody = try JSONSerialization.data(withJSONObject: body)
+                    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                } catch {
+                    completion(CloudCodeTransportResponse(
+                        statusCode: nil,
+                        data: nil,
+                        headers: [:],
+                        error: error
+                    ))
+                    return
+                }
+            }
+
+            self.cloudCodeSession.dataTask(with: request) { data, response, error in
+                let httpResponse = response as? HTTPURLResponse
+                var responseHeaders: [String: String] = [:]
+                httpResponse?.allHeaderFields.forEach { key, value in
+                    responseHeaders[String(describing: key)] = String(describing: value)
+                }
+
+                completion(CloudCodeTransportResponse(
+                    statusCode: httpResponse?.statusCode,
+                    data: data,
+                    headers: responseHeaders,
+                    error: error
+                ))
+            }.resume()
+        }
+    }
 }
+
+extension AppAmbitApiService: CloudCodeTransport {}

--- a/AppAmbitSdk/Sources/Services/AppAmbitApiService.swift
+++ b/AppAmbitSdk/Sources/Services/AppAmbitApiService.swift
@@ -125,7 +125,7 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
             self.processResponse(request: request, responseType: responseType) { result in
                 Queues.state.async {
                     switch result.errorType {
-                    case .unauthorized where !isTokenEndpoint && self.allowsUnauthorizedRetry(for: endpoint):
+                    case .unauthorized where !isTokenEndpoint:
                         self.clearToken()
                         self.handleTokenRefresh(
                             originalRequest: request,
@@ -643,7 +643,7 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
                     self.executeRawRequestAfterToken(
                         endpoint,
                         deadline: deadline,
-                        allowUnauthorizedRetry: self.allowsUnauthorizedRetry(for: endpoint),
+                        allowUnauthorizedRetry: true,
                         completion: completion
                     )
                 }) { _ in
@@ -660,14 +660,10 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
             self.executeRawRequestAfterToken(
                 endpoint,
                 deadline: deadline,
-                allowUnauthorizedRetry: self.allowsUnauthorizedRetry(for: endpoint),
+                allowUnauthorizedRetry: true,
                 completion: completion
             )
         }
-    }
-
-    private func allowsUnauthorizedRetry(for endpoint: Endpoint) -> Bool {
-        endpoint.method == .get
     }
 
     private func executeRawRequestAfterToken(
@@ -717,7 +713,6 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
 
             guard rawResponse.statusCode == 401,
                   allowUnauthorizedRetry,
-                  self.allowsUnauthorizedRetry(for: endpoint),
                   self.requiresConsumerToken(endpoint) else {
                 completion(rawResponse)
                 return

--- a/AppAmbitSdk/Sources/Services/AppAmbitApiService.swift
+++ b/AppAmbitSdk/Sources/Services/AppAmbitApiService.swift
@@ -13,27 +13,28 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
 
     // MARK: - Networking
 
-    private lazy var urlSession: URLSession = {
+    private let urlSession: URLSession
+    private let isConnected: @Sendable () -> Bool
+
+    private static func makeURLSession() -> URLSession {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 20
-        config.timeoutIntervalForResource = 20
+        config.timeoutIntervalForResource = AppConstants.cloudCodeTimeout
         config.waitsForConnectivity = true
         config.httpMaximumConnectionsPerHost = 2
         return URLSession(configuration: config)
-    }()
-
-    private lazy var cloudCodeSession: URLSession = {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForResource = 80
-        config.waitsForConnectivity = true
-        config.httpMaximumConnectionsPerHost = 2
-        return URLSession(configuration: config)
-    }()
+    }
 
     // MARK: - Init
 
-    init(storageService: StorageService) {
+    init(
+        storageService: StorageService,
+        urlSession: URLSession? = nil,
+        isConnected: @escaping @Sendable () -> Bool = { ServiceContainer.shared.reachabilityService.isConnected() }
+    ) {
         self.storageService = storageService
+        self.urlSession = urlSession ?? Self.makeURLSession()
+        self.isConnected = isConnected
     }
 
     // MARK: - Token (thread-safe using internal queue)
@@ -43,11 +44,13 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
     }
 
     func setToken(_ newToken: String) {
-        Queues.token.async(flags: .barrier) { self._token = newToken }
+        Queues.token.sync(flags: .barrier) {
+            self._token = newToken.isEmpty ? nil : newToken
+        }
     }
 
     private func clearToken() {
-        Queues.token.async(flags: .barrier) { self._token = "" }
+        setToken("")
     }
 
     // MARK: - Public API
@@ -57,10 +60,19 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
         responseType: T.Type,
         completion: @Sendable @escaping (ApiResult<T>) -> Void
     ) {
+        executeRequest(endpoint, responseType: responseType, allowTokenRefresh: true, completion: completion)
+    }
+
+    private func executeRequest<T: Decodable>(
+        _ endpoint: Endpoint,
+        responseType: T.Type,
+        allowTokenRefresh: Bool,
+        completion: @Sendable @escaping (ApiResult<T>) -> Void
+    ) {
         Queues.state.async { [weak self] in
             guard let self else { return }
 
-            if !ServiceContainer.shared.reachabilityService.isConnected() {
+            if !self.isConnected() {
                 completion(.fail(.unknown, message: "No internet connection"))
                 return
             }
@@ -72,42 +84,26 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
                 return
             }
 
-            guard let url = URL(string: endpoint.baseUrl + endpoint.url) else {
-                completion(.fail(.unknown, message: "Invalid URL"))
+            if allowTokenRefresh, self.requiresConsumerToken(endpoint), !self.hasToken {
+                self.refreshTokenAndRetryRequests(retry: {
+                    self.executeRequest(
+                        endpoint,
+                        responseType: responseType,
+                        allowTokenRefresh: false,
+                        completion: completion
+                    )
+                }) { error in
+                    completion(.fail(error, message: "Token renewal failure"))
+                }
                 return
             }
 
-            var request = URLRequest(url: url)
-            request.httpMethod = endpoint.method.stringValue
-
-            #if DEBUG
-            if endpoint is CmsEndpoint {
-                AppAmbitLogger.log(message: "CMS REQUEST URL: \(url.absoluteString)")
-            }
-            #endif
-
-            self.configureHeaders(for: &request, endpoint: endpoint)
-
-            if let payload = endpoint.payload {
-                if endpoint.method == .get {
-                    self.handleGETWithQueryParameters(
-                        payload: payload,
-                        request: &request,
-                        responseType: T.self,
-                        completion: completion
-                    )
-                } else {
-                    if self.isMultipartPayload(payload) {
-                        self.handleMultipartPayload(payload, request: &request)
-                    } else {
-                        self.handleJSONPayload(
-                            payload,
-                            request: &request,
-                            responseType: T.self,
-                            completion: completion
-                        )
-                    }
-                }
+            let request: URLRequest
+            do {
+                request = try self.buildRequest(for: endpoint, timeout: nil)
+            } catch {
+                completion(.fail(.unknown, message: error.localizedDescription))
+                return
             }
 
             let isTokenEndpoint = endpoint is TokenEndpoint
@@ -117,6 +113,7 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
                 Queues.state.async {
                     switch result.errorType {
                     case .unauthorized where !isTokenEndpoint:
+                        self.clearToken()
                         self.handleTokenRefresh(
                             originalRequest: request,
                             skipAuth: skipAuth,
@@ -129,6 +126,18 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
                 }
             }
         }
+    }
+
+    private var hasToken: Bool {
+        guard let token else { return false }
+        return !token.isEmpty
+    }
+
+    private func requiresConsumerToken(_ endpoint: Endpoint) -> Bool {
+        !(endpoint is TokenEndpoint) &&
+        !(endpoint is RegisterEndpoint) &&
+        !(endpoint is CmsEndpoint) &&
+        !endpoint.skipAuthorization
     }
 
     func getNewToken(completion: @escaping @Sendable (ApiErrorType) -> Void) {
@@ -229,7 +238,7 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
     private func configureHeaders(for request: inout URLRequest, endpoint: Endpoint) {
         if let headers = endpoint.customHeader {
             for (k, v) in headers {
-                request.addValue(v, forHTTPHeaderField: k)
+                request.setValue(v, forHTTPHeaderField: k)
             }
         }
         request.addValue("application/json", forHTTPHeaderField: "Accept")
@@ -249,40 +258,6 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
         }
     }
 
-    private func handleGETWithQueryParameters<T: Decodable>(
-        payload: Any,
-        request: inout URLRequest,
-        responseType: T.Type,
-        completion: @escaping (ApiResult<T>) -> Void
-    ) {
-        guard var urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false) else {
-            completion(.fail(.unknown, message: "Invalid URL"))
-            return
-        }
-
-        var queryItems = [URLQueryItem]()
-
-        if let dictConvertible = payload as? DictionaryConvertible {
-            let dictionary = dictConvertible.toDictionary()
-            queryItems = dictionary.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
-        } else if let dictionary = payload as? [String: Any] {
-            queryItems = dictionary.map { URLQueryItem(name: $0.key, value: "\($0.value)") }
-        }
-
-        urlComponents.queryItems = queryItems.isEmpty ? nil : queryItems
-
-        guard let urlWithQueryParams = urlComponents.url else {
-            completion(.fail(.unknown, message: "Invalid URL with query parameters"))
-            return
-        }
-
-        request.url = urlWithQueryParams
-
-        #if DEBUG
-        AppAmbitLogger.log(message: "HTTP - REQUEST - URL with QueryParams: \(request.url?.absoluteString ?? "N/A")")
-        #endif
-    }
-
     private func isMultipartPayload(_ payload: Any) -> Bool {
         payload is Log || payload is LogBatch
     }
@@ -300,32 +275,82 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
         printMultipartRequest(request: request, body: body)
     }
 
-    private func handleJSONPayload<T: Decodable>(
-        _ payload: Any,
-        request: inout URLRequest,
-        responseType: T.Type,
-        completion: @escaping (ApiResult<T>) -> Void
-    ) {
-        do {
-            let payloadDict = try convertToDictionary(payload: payload)
-            guard JSONSerialization.isValidJSONObject(payloadDict) else {
-                return completion(.fail(.unknown, message: "The payload object is not a valid JSON"))
-            }
-            let jsonData = try JSONSerialization.data(withJSONObject: payloadDict, options: [.prettyPrinted])
-            request.httpBody = jsonData
-            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
-            printJSONRequest(request: request, jsonData: jsonData)
-        } catch let error as ApiErrorType {
-            completion(.fail(error, message: "Payload not convertible"))
-        } catch {
-            completion(.fail(.unknown, message: "Error serializing payload: \(error.localizedDescription)"))
+    private func buildRequest(for endpoint: Endpoint, timeout: TimeInterval?) throws -> URLRequest {
+        guard let url = URL(string: endpoint.baseUrl + endpoint.url) else {
+            throw ApiExceptions.invalidURL
         }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = endpoint.method.stringValue
+        if let timeout {
+            request.timeoutInterval = timeout
+        }
+        configureHeaders(for: &request, endpoint: endpoint)
+
+        if let cloudCodeEndpoint = endpoint as? CloudCodeEndpoint {
+            // Cloud Code GET requests never carry a body, even if one was supplied.
+            if endpoint.method != .get, let bodyData = cloudCodeEndpoint.bodyData {
+                request.httpBody = bodyData
+                request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+                printJSONRequest(request: request, jsonData: bodyData)
+            }
+            return request
+        }
+
+        guard let payload = endpoint.payload else { return request }
+        if endpoint.method == .get {
+            try applyGETQueryParameters(payload: payload, request: &request)
+        } else if isMultipartPayload(payload) {
+            handleMultipartPayload(payload, request: &request)
+        } else {
+            let jsonData = try serializeJSONPayload(payload)
+            request.httpBody = jsonData
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            printJSONRequest(request: request, jsonData: jsonData)
+        }
+        return request
     }
 
-    private func convertToDictionary(payload: Any) throws -> [String: Any] {
-        if let convertible = payload as? DictionaryConvertible { return convertible.toDictionary() }
-        if let dict = payload as? [String: Any] { return dict }
-        throw ApiErrorType.unknown
+    private func applyGETQueryParameters(payload: Any, request: inout URLRequest) throws {
+        guard var urlComponents = request.url.flatMap({ URLComponents(url: $0, resolvingAgainstBaseURL: false) }) else {
+            throw ApiExceptions.invalidURL
+        }
+
+        let dictionary: [String: Any]
+        if let dictConvertible = payload as? DictionaryConvertible {
+            dictionary = dictConvertible.toDictionary()
+        } else if let dictionaryPayload = payload as? [String: Any] {
+            dictionary = dictionaryPayload
+        } else {
+            return
+        }
+
+        let queryItems = URLQueryBuilder.queryItems(from: dictionary)
+        urlComponents.queryItems = queryItems.isEmpty ? nil : queryItems
+        guard let urlWithQueryParams = urlComponents.url else {
+            throw ApiExceptions.invalidURL
+        }
+        request.url = urlWithQueryParams
+
+        #if DEBUG
+        AppAmbitLogger.log(message: "HTTP - REQUEST URL with QueryParams: \(urlWithQueryParams.absoluteString)")
+        #endif
+    }
+
+    private func serializeJSONPayload(_ payload: Any) throws -> Data {
+        let payloadDictionary: [String: Any]
+        if let convertible = payload as? DictionaryConvertible {
+            payloadDictionary = convertible.toDictionary()
+        } else if let dictionary = payload as? [String: Any] {
+            payloadDictionary = dictionary
+        } else {
+            throw ApiErrorType.unknown
+        }
+
+        guard JSONSerialization.isValidJSONObject(payloadDictionary) else {
+            throw ApiErrorType.unknown
+        }
+        return try JSONSerialization.data(withJSONObject: payloadDictionary, options: [.prettyPrinted])
     }
 
     // MARK: - Low level response/decoding
@@ -577,43 +602,16 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
         return result
     }
 
-    func executeCloudCodeRequest(
-        _ endpoint: CloudCodeEndpoint,
+    func executeRawRequest(
+        _ endpoint: Endpoint,
         timeout: TimeInterval,
-        completion: @escaping @Sendable (CloudCodeTransportResponse) -> Void
-    ) {
-        performCloudCodeRequest(endpoint, timeout: timeout) { [weak self] response in
-            guard let self else { return }
-            guard response.statusCode == 401 else {
-                completion(response)
-                return
-            }
-
-            self.refreshTokenAndRetryRequests(retry: {
-                [weak self] in
-                guard let self else { return }
-                self.performCloudCodeRequest(endpoint, timeout: timeout, completion: completion)
-            }) { _ in
-                completion(CloudCodeTransportResponse(
-                    statusCode: 401,
-                    data: response.data,
-                    headers: response.headers,
-                    error: nil
-                ))
-            }
-        }
-    }
-
-    private func performCloudCodeRequest(
-        _ endpoint: CloudCodeEndpoint,
-        timeout: TimeInterval,
-        completion: @escaping @Sendable (CloudCodeTransportResponse) -> Void
+        completion: @escaping @Sendable (HTTPTransportResponse) -> Void
     ) {
         Queues.state.async { [weak self] in
             guard let self else { return }
 
-            guard ServiceContainer.shared.reachabilityService.isConnected() else {
-                completion(CloudCodeTransportResponse(
+            guard self.isConnected() else {
+                completion(HTTPTransportResponse(
                     statusCode: nil,
                     data: nil,
                     headers: [:],
@@ -622,63 +620,86 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
                 return
             }
 
-            guard let url = URL(string: endpoint.baseUrl + endpoint.url) else {
-                completion(CloudCodeTransportResponse(
-                    statusCode: nil,
-                    data: nil,
-                    headers: [:],
-                    error: ApiExceptions.invalidURL
-                ))
+            if self.requiresConsumerToken(endpoint), !self.hasToken {
+                self.refreshTokenAndRetryRequests(retry: {
+                    self.executeRawRequestAfterToken(
+                        endpoint,
+                        timeout: timeout,
+                        allowUnauthorizedRetry: true,
+                        completion: completion
+                    )
+                }) { _ in
+                    completion(HTTPTransportResponse(
+                        statusCode: 401,
+                        data: nil,
+                        headers: [:],
+                        error: nil
+                    ))
+                }
                 return
             }
 
-            var request = URLRequest(url: url)
-            request.httpMethod = endpoint.method.stringValue
-            request.timeoutInterval = timeout
-
-            if let customHeaders = endpoint.customHeader {
-                for (key, value) in customHeaders {
-                    request.setValue(value, forHTTPHeaderField: key)
-                }
-            }
-
-            request.setValue("application/json", forHTTPHeaderField: "Accept")
-
-            if let token = self.token {
-                request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            }
-
-            if let body = endpoint.payload as? [String: Any] {
-                do {
-                    request.httpBody = try JSONSerialization.data(withJSONObject: body)
-                    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-                } catch {
-                    completion(CloudCodeTransportResponse(
-                        statusCode: nil,
-                        data: nil,
-                        headers: [:],
-                        error: error
-                    ))
-                    return
-                }
-            }
-
-            self.cloudCodeSession.dataTask(with: request) { data, response, error in
-                let httpResponse = response as? HTTPURLResponse
-                var responseHeaders: [String: String] = [:]
-                httpResponse?.allHeaderFields.forEach { key, value in
-                    responseHeaders[String(describing: key)] = String(describing: value)
-                }
-
-                completion(CloudCodeTransportResponse(
-                    statusCode: httpResponse?.statusCode,
-                    data: data,
-                    headers: responseHeaders,
-                    error: error
-                ))
-            }.resume()
+            self.executeRawRequestAfterToken(
+                endpoint,
+                timeout: timeout,
+                allowUnauthorizedRetry: true,
+                completion: completion
+            )
         }
     }
-}
 
-extension AppAmbitApiService: CloudCodeTransport {}
+    private func executeRawRequestAfterToken(
+        _ endpoint: Endpoint,
+        timeout: TimeInterval,
+        allowUnauthorizedRetry: Bool,
+        completion: @escaping @Sendable (HTTPTransportResponse) -> Void
+    ) {
+        let request: URLRequest
+        do {
+            request = try buildRequest(for: endpoint, timeout: timeout)
+        } catch {
+            completion(HTTPTransportResponse(
+                statusCode: nil,
+                data: nil,
+                headers: [:],
+                error: error
+            ))
+            return
+        }
+
+        urlSession.dataTask(with: request) { [weak self] data, response, error in
+            guard let self else { return }
+            let httpResponse = response as? HTTPURLResponse
+            var responseHeaders: [String: String] = [:]
+            httpResponse?.allHeaderFields.forEach { key, value in
+                responseHeaders[String(describing: key)] = String(describing: value)
+            }
+
+            let rawResponse = HTTPTransportResponse(
+                statusCode: httpResponse?.statusCode,
+                data: data,
+                headers: responseHeaders,
+                error: error
+            )
+
+            guard rawResponse.statusCode == 401,
+                  allowUnauthorizedRetry,
+                  self.requiresConsumerToken(endpoint) else {
+                completion(rawResponse)
+                return
+            }
+
+            self.clearToken()
+            self.refreshTokenAndRetryRequests(retry: {
+                self.executeRawRequestAfterToken(
+                    endpoint,
+                    timeout: timeout,
+                    allowUnauthorizedRetry: false,
+                    completion: completion
+                )
+            }) { _ in
+                completion(rawResponse)
+            }
+        }.resume()
+    }
+}

--- a/AppAmbitSdk/Sources/Services/AppAmbitApiService.swift
+++ b/AppAmbitSdk/Sources/Services/AppAmbitApiService.swift
@@ -125,7 +125,7 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
             self.processResponse(request: request, responseType: responseType) { result in
                 Queues.state.async {
                     switch result.errorType {
-                    case .unauthorized where !isTokenEndpoint:
+                    case .unauthorized where !isTokenEndpoint && self.allowsUnauthorizedRetry(for: endpoint):
                         self.clearToken()
                         self.handleTokenRefresh(
                             originalRequest: request,
@@ -377,7 +377,7 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
         responseType: T.Type,
         completion: @escaping @Sendable (ApiResult<T>) -> Void
     ) {
-        cloudCodeSession.dataTask(with: request) { [weak self] data, response, error in
+        urlSession.dataTask(with: request) { [weak self] data, response, error in
             guard let self else { return }
 
             Queues.netDecode.async {
@@ -624,6 +624,7 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
         timeout: TimeInterval,
         completion: @escaping @Sendable (HTTPTransportResponse) -> Void
     ) {
+        let deadline = Date().addingTimeInterval(timeout)
         Queues.state.async { [weak self] in
             guard let self else { return }
 
@@ -641,8 +642,8 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
                 self.refreshTokenAndRetryRequests(retry: {
                     self.executeRawRequestAfterToken(
                         endpoint,
-                        timeout: timeout,
-                        allowUnauthorizedRetry: true,
+                        deadline: deadline,
+                        allowUnauthorizedRetry: self.allowsUnauthorizedRetry(for: endpoint),
                         completion: completion
                     )
                 }) { _ in
@@ -658,22 +659,37 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
 
             self.executeRawRequestAfterToken(
                 endpoint,
-                timeout: timeout,
-                allowUnauthorizedRetry: true,
+                deadline: deadline,
+                allowUnauthorizedRetry: self.allowsUnauthorizedRetry(for: endpoint),
                 completion: completion
             )
         }
     }
 
+    private func allowsUnauthorizedRetry(for endpoint: Endpoint) -> Bool {
+        endpoint.method == .get
+    }
+
     private func executeRawRequestAfterToken(
         _ endpoint: Endpoint,
-        timeout: TimeInterval,
+        deadline: Date,
         allowUnauthorizedRetry: Bool,
         completion: @escaping @Sendable (HTTPTransportResponse) -> Void
     ) {
+        let remaining = deadline.timeIntervalSinceNow
+        guard remaining > 0 else {
+            completion(HTTPTransportResponse(
+                statusCode: nil,
+                data: nil,
+                headers: [:],
+                error: URLError(.timedOut)
+            ))
+            return
+        }
+
         let request: URLRequest
         do {
-            request = try buildRequest(for: endpoint, timeout: timeout)
+            request = try buildRequest(for: endpoint, timeout: remaining)
         } catch {
             completion(HTTPTransportResponse(
                 statusCode: nil,
@@ -684,7 +700,7 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
             return
         }
 
-        urlSession.dataTask(with: request) { [weak self] data, response, error in
+        cloudCodeSession.dataTask(with: request) { [weak self] data, response, error in
             guard let self else { return }
             let httpResponse = response as? HTTPURLResponse
             var responseHeaders: [String: String] = [:]
@@ -701,6 +717,7 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
 
             guard rawResponse.statusCode == 401,
                   allowUnauthorizedRetry,
+                  self.allowsUnauthorizedRetry(for: endpoint),
                   self.requiresConsumerToken(endpoint) else {
                 completion(rawResponse)
                 return
@@ -710,7 +727,7 @@ final class AppAmbitApiService: ApiService, @unchecked Sendable {
             self.refreshTokenAndRetryRequests(retry: {
                 self.executeRawRequestAfterToken(
                     endpoint,
-                    timeout: timeout,
+                    deadline: deadline,
                     allowUnauthorizedRetry: false,
                     completion: completion
                 )

--- a/AppAmbitSdk/Sources/Services/CloudCodeService.swift
+++ b/AppAmbitSdk/Sources/Services/CloudCodeService.swift
@@ -21,7 +21,7 @@ final class CloudCodeService: @unchecked Sendable {
         let cancellation = CloudCodeCancellationToken()
 
         if let validationError = validationError(function: function, body: body, headers: headers) {
-            deliverOnMain { completion(nil, validationError) }
+            deliverOnMain(cancellation: cancellation) { completion(nil, validationError) }
             return cancellation
         }
 
@@ -36,7 +36,7 @@ final class CloudCodeService: @unchecked Sendable {
         execute(endpoint, cancellation: cancellation) { response in
             switch Self.validateSuccessfulResponse(response) {
             case .failure(let error):
-                self.deliverOnMain { completion(nil, error) }
+                self.deliverOnMain(cancellation: cancellation) { completion(nil, error) }
             case .success(let metadata):
                 do {
                     let data = try Self.anyValue(from: response.data, statusCode: metadata.statusCode)
@@ -46,13 +46,15 @@ final class CloudCodeService: @unchecked Sendable {
                         requestId: metadata.requestId,
                         headers: metadata.headers
                     )
-                    self.deliverOnMain {
+                    self.deliverOnMain(cancellation: cancellation) {
                         completion(cloudResponse, nil)
                     }
                 } catch let error as CloudCodeError {
-                    self.deliverOnMain { completion(nil, error) }
+                    self.deliverOnMain(cancellation: cancellation) { completion(nil, error) }
                 } catch {
-                    self.deliverOnMain { completion(nil, CloudCodeError.decoding(error.localizedDescription)) }
+                    self.deliverOnMain(cancellation: cancellation) {
+                        completion(nil, CloudCodeError.decoding(error.localizedDescription))
+                    }
                 }
             }
         }
@@ -73,7 +75,7 @@ final class CloudCodeService: @unchecked Sendable {
         let cancellation = CloudCodeCancellationToken()
 
         if let validationError = validationError(function: function, body: body, headers: headers) {
-            deliverOnMain { completion(nil, validationError) }
+            deliverOnMain(cancellation: cancellation) { completion(nil, validationError) }
             return cancellation
         }
         let endpoint = CloudCodeEndpoint(function: function, method: method, query: query, body: body, headers: headers)
@@ -81,10 +83,10 @@ final class CloudCodeService: @unchecked Sendable {
         execute(endpoint, cancellation: cancellation) { response in
             switch Self.validateSuccessfulResponse(response) {
             case .failure(let error):
-                self.deliverOnMain { completion(nil, error) }
+                self.deliverOnMain(cancellation: cancellation) { completion(nil, error) }
             case .success(let metadata):
                 guard let responseData = response.data, !responseData.isEmpty else {
-                    self.deliverOnMain {
+                    self.deliverOnMain(cancellation: cancellation) {
                         completion(
                             CloudCodeResult(
                                 data: nil,
@@ -106,11 +108,13 @@ final class CloudCodeService: @unchecked Sendable {
                         requestId: metadata.requestId,
                         headers: metadata.headers
                     )
-                    self.deliverOnMain {
+                    self.deliverOnMain(cancellation: cancellation) {
                         completion(result, nil)
                     }
                 } catch {
-                    self.deliverOnMain { completion(nil, .decoding(error.localizedDescription)) }
+                    self.deliverOnMain(cancellation: cancellation) {
+                        completion(nil, .decoding(error.localizedDescription))
+                    }
                 }
             }
         }
@@ -129,8 +133,14 @@ final class CloudCodeService: @unchecked Sendable {
         }
     }
 
-    private func deliverOnMain(_ completion: @escaping @Sendable () -> Void) {
-        DispatchQueue.main.async(execute: completion)
+    private func deliverOnMain(
+        cancellation: CloudCodeCancellationToken,
+        _ completion: @escaping @Sendable () -> Void
+    ) {
+        DispatchQueue.main.async {
+            guard !cancellation.isCancelled else { return }
+            completion()
+        }
     }
 
     private func validationError(function: String, body: [String: Any]?, headers: [String: String]?) -> CloudCodeError? {
@@ -150,7 +160,7 @@ final class CloudCodeService: @unchecked Sendable {
             return .failure(.decoding("Missing HTTP status code."))
         }
         guard (200..<300).contains(statusCode) else {
-            let parsed = jsonValue(from: response.data)
+            let parsed = jsonObjectOrArray(from: response.data)
             let rawBody = parsed == nil ? response.data.flatMap { String(data: $0, encoding: .utf8) } : nil
             return .failure(.http(statusCode: statusCode, body: parsed, rawBody: rawBody, requestId: requestId(from: response)))
         }
@@ -193,13 +203,19 @@ final class CloudCodeService: @unchecked Sendable {
         }?.key
     }
 
-    private static func jsonValue(from data: Data?) -> JSONValue? {
+    private static func jsonObjectOrArray(from data: Data?) -> JSONValue? {
         guard let data,
               !data.isEmpty else { return nil }
         guard let object = try? JSONSerialization.jsonObject(with: data, options: [.allowFragments]) else {
             return nil
         }
-        return JSONValue.from(any: object)
+        let value = JSONValue.from(any: object)
+        switch value {
+        case .object, .array:
+            return value
+        default:
+            return nil
+        }
     }
 
     private static func anyValue(from data: Data?, statusCode: Int) throws -> Any {

--- a/AppAmbitSdk/Sources/Services/CloudCodeService.swift
+++ b/AppAmbitSdk/Sources/Services/CloudCodeService.swift
@@ -1,0 +1,189 @@
+import Foundation
+
+final class CloudCodeService: @unchecked Sendable {
+    static let defaultTimeout: TimeInterval = 60
+
+    private let transport: CloudCodeTransport
+
+    init(transport: CloudCodeTransport) {
+        self.transport = transport
+    }
+
+    @discardableResult
+    func call(
+        function: String,
+        method: CloudCodeHttpMethod,
+        query: [String: String]?,
+        body: [String: Any]?,
+        headers: [String: String]?,
+        completion: @escaping @Sendable (CloudCodeResponse?, Error?) -> Void
+    ) -> CloudCodeCancellationToken {
+        let cancellation = CloudCodeCancellationToken()
+
+        if let validationError = validationError(function: function, body: body, headers: headers) {
+            completion(nil, validationError)
+            return cancellation
+        }
+
+        let endpoint = CloudCodeEndpoint(
+            function: function,
+            method: method,
+            query: query,
+            body: body,
+            headers: headers
+        )
+
+        execute(endpoint, cancellation: cancellation) { response in
+            switch Self.validateSuccessfulResponse(response) {
+            case .failure(let error):
+                completion(nil, error)
+            case .success(let metadata):
+                completion(
+                    CloudCodeResponse(
+                        data: Self.anyValue(from: response.data),
+                        statusCode: metadata.statusCode,
+                        requestId: metadata.requestId
+                    ),
+                    nil
+                )
+            }
+        }
+
+        return cancellation
+    }
+
+    @discardableResult
+    func call<T: Decodable>(
+        function: String,
+        method: CloudCodeHttpMethod,
+        query: [String: String]?,
+        body: [String: Any]?,
+        headers: [String: String]?,
+        as type: T.Type,
+        completion: @escaping @Sendable (CloudCodeResult<T>?, CloudCodeError?) -> Void
+    ) -> CloudCodeCancellationToken {
+        let cancellation = CloudCodeCancellationToken()
+
+        if let validationError = validationError(function: function, body: body, headers: headers) {
+            completion(nil, validationError)
+            return cancellation
+        }
+        let endpoint = CloudCodeEndpoint(function: function, method: method, query: query, body: body, headers: headers)
+
+        execute(endpoint, cancellation: cancellation) { response in
+            switch Self.validateSuccessfulResponse(response) {
+            case .failure(let error):
+                completion(nil, error)
+            case .success(let metadata):
+                if metadata.statusCode == 204 {
+                    // A 204 is successful but has no T to construct. Preserve the existing API contract.
+                    completion(nil, nil)
+                    return
+                }
+
+                guard let responseData = response.data, !responseData.isEmpty else {
+                    completion(nil, .decoding("The response body is empty."))
+                    return
+                }
+
+                do {
+                    let value = try JSONDecoder().decode(T.self, from: responseData)
+                    completion(CloudCodeResult(data: value, statusCode: metadata.statusCode, requestId: metadata.requestId), nil)
+                } catch {
+                    completion(nil, .decoding(error.localizedDescription))
+                }
+            }
+        }
+
+        return cancellation
+    }
+
+    private func execute(
+        _ endpoint: CloudCodeEndpoint,
+        cancellation: CloudCodeCancellationToken,
+        completion: @escaping @Sendable (CloudCodeTransportResponse) -> Void
+    ) {
+        transport.executeCloudCodeRequest(endpoint, timeout: Self.defaultTimeout) { response in
+            guard !cancellation.isCancelled else { return }
+            completion(response)
+        }
+    }
+
+    private func validationError(function: String, body: [String: Any]?, headers: [String: String]?) -> CloudCodeError? {
+        if !isValidFunction(function) { return .invalidFunction(function) }
+        if let invalidHeader = invalidReservedHeader(in: headers) { return .invalidHeader(invalidHeader) }
+        if let body, !JSONSerialization.isValidJSONObject(body) { return .invalidBody }
+        return nil
+    }
+
+    private static func validateSuccessfulResponse(
+        _ response: CloudCodeTransportResponse
+    ) -> Result<(statusCode: Int, requestId: String?), CloudCodeError> {
+        if let error = response.error {
+            return .failure(transportError(from: error))
+        }
+        guard let statusCode = response.statusCode else {
+            return .failure(.decoding("Missing HTTP status code."))
+        }
+        guard (200..<300).contains(statusCode) else {
+            let parsed = jsonValue(from: response.data)
+            let rawBody = parsed == nil ? response.data.flatMap { String(data: $0, encoding: .utf8) } : nil
+            return .failure(.http(statusCode: statusCode, body: parsed, rawBody: rawBody, requestId: requestId(from: response)))
+        }
+        return .success((statusCode, requestId(from: response)))
+    }
+
+    private static func transportError(from error: Error) -> CloudCodeError {
+        if let error = error as? ApiExceptions, case .invalidURL = error { return .invalidURL }
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .notConnectedToInternet, .networkConnectionLost:
+                return .networkUnavailable
+            case .timedOut:
+                return .timedOut
+            default:
+                return .transport(urlError.localizedDescription)
+            }
+        }
+        return .transport(error.localizedDescription)
+    }
+
+    private func isValidFunction(_ function: String) -> Bool {
+        !function.isEmpty && !function.contains("/")
+    }
+
+    private func invalidReservedHeader(in headers: [String: String]?) -> String? {
+        let reserved = Set([
+            "authorization", "cookie", "host", "content-length", "content-type", "accept",
+            "x-app-key", "x-request-id", "x-forwarded-for", "x-forwarded-host",
+            "x-forwarded-proto", "x-amzn-trace-id"
+        ])
+        return headers?.keys.first { reserved.contains($0.lowercased()) }
+    }
+
+    private static func jsonValue(from data: Data?) -> JSONValue? {
+        guard let data,
+              !data.isEmpty else { return nil }
+        guard let object = try? JSONSerialization.jsonObject(with: data, options: [.allowFragments]) else {
+            return nil
+        }
+        return JSONValue.from(any: object)
+    }
+
+    private static func anyValue(from data: Data?) -> Any {
+        guard let data, !data.isEmpty,
+              let object = try? JSONSerialization.jsonObject(with: data, options: [.allowFragments]) else {
+            return NSNull()
+        }
+        return JSONValue.from(any: object).toAny()
+    }
+
+    private static func requestId(from response: CloudCodeTransportResponse) -> String? {
+        if let header = response.headers.first(where: { $0.key.caseInsensitiveCompare("X-Request-Id") == .orderedSame })?.value {
+            return header
+        }
+        guard let data = response.data,
+              let object = try? JSONSerialization.jsonObject(with: data, options: [.allowFragments]) as? [String: Any] else { return nil }
+        return object["request_id"] as? String
+    }
+}

--- a/AppAmbitSdk/Sources/Services/CloudCodeService.swift
+++ b/AppAmbitSdk/Sources/Services/CloudCodeService.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 final class CloudCodeService: @unchecked Sendable {
-    static let defaultTimeout: TimeInterval = 60
+    static let defaultTimeout: TimeInterval = AppConstants.cloudCodeTimeout
 
-    private let transport: CloudCodeTransport
+    private let transport: HTTPTransport
 
-    init(transport: CloudCodeTransport) {
+    init(transport: HTTPTransport) {
         self.transport = transport
     }
 
@@ -38,14 +38,21 @@ final class CloudCodeService: @unchecked Sendable {
             case .failure(let error):
                 completion(nil, error)
             case .success(let metadata):
-                completion(
-                    CloudCodeResponse(
-                        data: Self.anyValue(from: response.data),
-                        statusCode: metadata.statusCode,
-                        requestId: metadata.requestId
-                    ),
-                    nil
-                )
+                do {
+                    completion(
+                        CloudCodeResponse(
+                            data: try Self.anyValue(from: response.data, statusCode: metadata.statusCode),
+                            statusCode: metadata.statusCode,
+                            requestId: metadata.requestId,
+                            headers: metadata.headers
+                        ),
+                        nil
+                    )
+                } catch let error as CloudCodeError {
+                    completion(nil, error)
+                } catch {
+                    completion(nil, CloudCodeError.decoding(error.localizedDescription))
+                }
             }
         }
 
@@ -88,7 +95,15 @@ final class CloudCodeService: @unchecked Sendable {
 
                 do {
                     let value = try JSONDecoder().decode(T.self, from: responseData)
-                    completion(CloudCodeResult(data: value, statusCode: metadata.statusCode, requestId: metadata.requestId), nil)
+                    completion(
+                        CloudCodeResult(
+                            data: value,
+                            statusCode: metadata.statusCode,
+                            requestId: metadata.requestId,
+                            headers: metadata.headers
+                        ),
+                        nil
+                    )
                 } catch {
                     completion(nil, .decoding(error.localizedDescription))
                 }
@@ -101,9 +116,9 @@ final class CloudCodeService: @unchecked Sendable {
     private func execute(
         _ endpoint: CloudCodeEndpoint,
         cancellation: CloudCodeCancellationToken,
-        completion: @escaping @Sendable (CloudCodeTransportResponse) -> Void
+        completion: @escaping @Sendable (HTTPTransportResponse) -> Void
     ) {
-        transport.executeCloudCodeRequest(endpoint, timeout: Self.defaultTimeout) { response in
+        transport.executeRawRequest(endpoint, timeout: Self.defaultTimeout) { response in
             guard !cancellation.isCancelled else { return }
             completion(response)
         }
@@ -117,8 +132,8 @@ final class CloudCodeService: @unchecked Sendable {
     }
 
     private static func validateSuccessfulResponse(
-        _ response: CloudCodeTransportResponse
-    ) -> Result<(statusCode: Int, requestId: String?), CloudCodeError> {
+        _ response: HTTPTransportResponse
+    ) -> Result<(statusCode: Int, headers: [String: String], requestId: String?), CloudCodeError> {
         if let error = response.error {
             return .failure(transportError(from: error))
         }
@@ -130,7 +145,7 @@ final class CloudCodeService: @unchecked Sendable {
             let rawBody = parsed == nil ? response.data.flatMap { String(data: $0, encoding: .utf8) } : nil
             return .failure(.http(statusCode: statusCode, body: parsed, rawBody: rawBody, requestId: requestId(from: response)))
         }
-        return .success((statusCode, requestId(from: response)))
+        return .success((statusCode, response.headers, requestId(from: response)))
     }
 
     private static func transportError(from error: Error) -> CloudCodeError {
@@ -149,16 +164,27 @@ final class CloudCodeService: @unchecked Sendable {
     }
 
     private func isValidFunction(_ function: String) -> Bool {
-        !function.isEmpty && !function.contains("/")
+        guard !function.isEmpty, !function.contains("/") else { return false }
+        return !function.unicodeScalars.contains { scalar in
+            CharacterSet.whitespacesAndNewlines.contains(scalar) ||
+            CharacterSet.controlCharacters.contains(scalar)
+        }
     }
 
     private func invalidReservedHeader(in headers: [String: String]?) -> String? {
         let reserved = Set([
             "authorization", "cookie", "host", "content-length", "content-type", "accept",
-            "x-app-key", "x-request-id", "x-forwarded-for", "x-forwarded-host",
-            "x-forwarded-proto", "x-amzn-trace-id"
+            "x-app-key", "x-request-id", "x-correlation-id", "x-trace-id", "traceparent",
+            "tracestate", "x-forwarded-for", "x-forwarded-host", "x-forwarded-proto",
+            "x-amzn-trace-id"
         ])
-        return headers?.keys.first { reserved.contains($0.lowercased()) }
+
+        return headers?.first { key, value in
+            let normalized = key.lowercased()
+            return key.isEmpty || value.contains("\r") || value.contains("\n") ||
+                reserved.contains(normalized) || normalized.hasPrefix("x-appambit-") ||
+                normalized.hasPrefix("x-internal-")
+        }?.key
     }
 
     private static func jsonValue(from data: Data?) -> JSONValue? {
@@ -170,15 +196,18 @@ final class CloudCodeService: @unchecked Sendable {
         return JSONValue.from(any: object)
     }
 
-    private static func anyValue(from data: Data?) -> Any {
-        guard let data, !data.isEmpty,
-              let object = try? JSONSerialization.jsonObject(with: data, options: [.allowFragments]) else {
-            return NSNull()
+    private static func anyValue(from data: Data?, statusCode: Int) throws -> Any {
+        guard statusCode != 204 else { return NSNull() }
+        guard let data, !data.isEmpty else { return NSNull() }
+        do {
+            let object = try JSONSerialization.jsonObject(with: data, options: [.allowFragments])
+            return JSONValue.from(any: object).toAny()
+        } catch {
+            throw CloudCodeError.decoding("The response body is not valid JSON.")
         }
-        return JSONValue.from(any: object).toAny()
     }
 
-    private static func requestId(from response: CloudCodeTransportResponse) -> String? {
+    private static func requestId(from response: HTTPTransportResponse) -> String? {
         if let header = response.headers.first(where: { $0.key.caseInsensitiveCompare("X-Request-Id") == .orderedSame })?.value {
             return header
         }

--- a/AppAmbitSdk/Sources/Services/CloudCodeService.swift
+++ b/AppAmbitSdk/Sources/Services/CloudCodeService.swift
@@ -21,7 +21,7 @@ final class CloudCodeService: @unchecked Sendable {
         let cancellation = CloudCodeCancellationToken()
 
         if let validationError = validationError(function: function, body: body, headers: headers) {
-            completion(nil, validationError)
+            deliverOnMain { completion(nil, validationError) }
             return cancellation
         }
 
@@ -36,22 +36,23 @@ final class CloudCodeService: @unchecked Sendable {
         execute(endpoint, cancellation: cancellation) { response in
             switch Self.validateSuccessfulResponse(response) {
             case .failure(let error):
-                completion(nil, error)
+                self.deliverOnMain { completion(nil, error) }
             case .success(let metadata):
                 do {
-                    completion(
-                        CloudCodeResponse(
-                            data: try Self.anyValue(from: response.data, statusCode: metadata.statusCode),
-                            statusCode: metadata.statusCode,
-                            requestId: metadata.requestId,
-                            headers: metadata.headers
-                        ),
-                        nil
+                    let data = try Self.anyValue(from: response.data, statusCode: metadata.statusCode)
+                    let cloudResponse = CloudCodeResponse(
+                        data: data,
+                        statusCode: metadata.statusCode,
+                        requestId: metadata.requestId,
+                        headers: metadata.headers
                     )
+                    self.deliverOnMain {
+                        completion(cloudResponse, nil)
+                    }
                 } catch let error as CloudCodeError {
-                    completion(nil, error)
+                    self.deliverOnMain { completion(nil, error) }
                 } catch {
-                    completion(nil, CloudCodeError.decoding(error.localizedDescription))
+                    self.deliverOnMain { completion(nil, CloudCodeError.decoding(error.localizedDescription)) }
                 }
             }
         }
@@ -72,7 +73,7 @@ final class CloudCodeService: @unchecked Sendable {
         let cancellation = CloudCodeCancellationToken()
 
         if let validationError = validationError(function: function, body: body, headers: headers) {
-            completion(nil, validationError)
+            deliverOnMain { completion(nil, validationError) }
             return cancellation
         }
         let endpoint = CloudCodeEndpoint(function: function, method: method, query: query, body: body, headers: headers)
@@ -80,32 +81,36 @@ final class CloudCodeService: @unchecked Sendable {
         execute(endpoint, cancellation: cancellation) { response in
             switch Self.validateSuccessfulResponse(response) {
             case .failure(let error):
-                completion(nil, error)
+                self.deliverOnMain { completion(nil, error) }
             case .success(let metadata):
-                if metadata.statusCode == 204 {
-                    // A 204 is successful but has no T to construct. Preserve the existing API contract.
-                    completion(nil, nil)
-                    return
-                }
-
                 guard let responseData = response.data, !responseData.isEmpty else {
-                    completion(nil, .decoding("The response body is empty."))
+                    self.deliverOnMain {
+                        completion(
+                            CloudCodeResult(
+                                data: nil,
+                                statusCode: metadata.statusCode,
+                                requestId: metadata.requestId,
+                                headers: metadata.headers
+                            ),
+                            nil
+                        )
+                    }
                     return
                 }
 
                 do {
                     let value = try JSONDecoder().decode(T.self, from: responseData)
-                    completion(
-                        CloudCodeResult(
-                            data: value,
-                            statusCode: metadata.statusCode,
-                            requestId: metadata.requestId,
-                            headers: metadata.headers
-                        ),
-                        nil
+                    let result = CloudCodeResult(
+                        data: value,
+                        statusCode: metadata.statusCode,
+                        requestId: metadata.requestId,
+                        headers: metadata.headers
                     )
+                    self.deliverOnMain {
+                        completion(result, nil)
+                    }
                 } catch {
-                    completion(nil, .decoding(error.localizedDescription))
+                    self.deliverOnMain { completion(nil, .decoding(error.localizedDescription)) }
                 }
             }
         }
@@ -122,6 +127,10 @@ final class CloudCodeService: @unchecked Sendable {
             guard !cancellation.isCancelled else { return }
             completion(response)
         }
+    }
+
+    private func deliverOnMain(_ completion: @escaping @Sendable () -> Void) {
+        DispatchQueue.main.async(execute: completion)
     }
 
     private func validationError(function: String, body: [String: Any]?, headers: [String: String]?) -> CloudCodeError? {
@@ -174,16 +183,13 @@ final class CloudCodeService: @unchecked Sendable {
     private func invalidReservedHeader(in headers: [String: String]?) -> String? {
         let reserved = Set([
             "authorization", "cookie", "host", "content-length", "content-type", "accept",
-            "x-app-key", "x-request-id", "x-correlation-id", "x-trace-id", "traceparent",
-            "tracestate", "x-forwarded-for", "x-forwarded-host", "x-forwarded-proto",
-            "x-amzn-trace-id"
+            "x-app-key", "x-request-id"
         ])
 
         return headers?.first { key, value in
             let normalized = key.lowercased()
             return key.isEmpty || value.contains("\r") || value.contains("\n") ||
-                reserved.contains(normalized) || normalized.hasPrefix("x-appambit-") ||
-                normalized.hasPrefix("x-internal-")
+                reserved.contains(normalized)
         }?.key
     }
 

--- a/AppAmbitSdk/Sources/Services/CloudCodeTransport.swift
+++ b/AppAmbitSdk/Sources/Services/CloudCodeTransport.swift
@@ -1,16 +1,18 @@
 import Foundation
 
-struct CloudCodeTransportResponse: @unchecked Sendable {
+struct HTTPTransportResponse: @unchecked Sendable {
     let statusCode: Int?
     let data: Data?
     let headers: [String: String]
     let error: Error?
 }
 
-protocol CloudCodeTransport: AnyObject {
-    func executeCloudCodeRequest(
-        _ endpoint: CloudCodeEndpoint,
+typealias CloudCodeTransportResponse = HTTPTransportResponse
+
+protocol HTTPTransport: AnyObject {
+    func executeRawRequest(
+        _ endpoint: Endpoint,
         timeout: TimeInterval,
-        completion: @escaping @Sendable (CloudCodeTransportResponse) -> Void
+        completion: @escaping @Sendable (HTTPTransportResponse) -> Void
     )
 }

--- a/AppAmbitSdk/Sources/Services/CloudCodeTransport.swift
+++ b/AppAmbitSdk/Sources/Services/CloudCodeTransport.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+struct CloudCodeTransportResponse: @unchecked Sendable {
+    let statusCode: Int?
+    let data: Data?
+    let headers: [String: String]
+    let error: Error?
+}
+
+protocol CloudCodeTransport: AnyObject {
+    func executeCloudCodeRequest(
+        _ endpoint: CloudCodeEndpoint,
+        timeout: TimeInterval,
+        completion: @escaping @Sendable (CloudCodeTransportResponse) -> Void
+    )
+}

--- a/AppAmbitSdk/Sources/Services/Endpoints/CloudCodeEndpoint.swift
+++ b/AppAmbitSdk/Sources/Services/Endpoints/CloudCodeEndpoint.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+final class CloudCodeEndpoint: BaseEndpoint, @unchecked Sendable {
+    init(
+        function: String,
+        method: CloudCodeHttpMethod,
+        query: [String: String]?,
+        body: [String: Any]?,
+        headers: [String: String]?
+    ) {
+        super.init()
+        self.url = Self.path(function: function, query: query)
+        self.method = method.apiMethod
+        self.payload = body
+        self.customHeader = headers
+    }
+
+    private static func path(function: String, query: [String: String]?) -> String {
+        var components = URLComponents()
+        let allowedSegmentCharacters = CharacterSet.alphanumerics.union(.init(charactersIn: "-._~"))
+        let encodedFunction = function.addingPercentEncoding(withAllowedCharacters: allowedSegmentCharacters) ?? function
+        components.percentEncodedPath = "/fn/\(encodedFunction)"
+        if let query {
+            components.queryItems = query
+                .sorted { $0.key < $1.key }
+                .map { URLQueryItem(name: $0.key, value: $0.value) }
+        }
+        return components.string ?? "/fn/\(function)"
+    }
+}

--- a/AppAmbitSdk/Sources/Services/Endpoints/CloudCodeEndpoint.swift
+++ b/AppAmbitSdk/Sources/Services/Endpoints/CloudCodeEndpoint.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 final class CloudCodeEndpoint: BaseEndpoint, @unchecked Sendable {
+    let bodyData: Data?
+
     init(
         function: String,
         method: CloudCodeHttpMethod,
@@ -8,6 +10,7 @@ final class CloudCodeEndpoint: BaseEndpoint, @unchecked Sendable {
         body: [String: Any]?,
         headers: [String: String]?
     ) {
+        bodyData = body.flatMap { try? JSONSerialization.data(withJSONObject: $0) }
         super.init()
         self.url = Self.path(function: function, query: query)
         self.method = method.apiMethod
@@ -16,15 +19,11 @@ final class CloudCodeEndpoint: BaseEndpoint, @unchecked Sendable {
     }
 
     private static func path(function: String, query: [String: String]?) -> String {
-        var components = URLComponents()
         let allowedSegmentCharacters = CharacterSet.alphanumerics.union(.init(charactersIn: "-._~"))
         let encodedFunction = function.addingPercentEncoding(withAllowedCharacters: allowedSegmentCharacters) ?? function
-        components.percentEncodedPath = "/fn/\(encodedFunction)"
-        if let query {
-            components.queryItems = query
-                .sorted { $0.key < $1.key }
-                .map { URLQueryItem(name: $0.key, value: $0.value) }
-        }
-        return components.string ?? "/fn/\(function)"
+        return URLQueryBuilder.append(
+            query: query,
+            toPath: "/fn/\(encodedFunction)"
+        )
     }
 }

--- a/AppAmbitSdk/Sources/Services/Protocols/ApiService.swift
+++ b/AppAmbitSdk/Sources/Services/Protocols/ApiService.swift
@@ -1,4 +1,4 @@
-protocol ApiService {
+protocol ApiService: HTTPTransport {
     func executeRequest<T: Decodable>(
         _ endpoint: Endpoint,
         responseType: T.Type,

--- a/AppAmbitSdk/Sources/Services/TokenService.swift
+++ b/AppAmbitSdk/Sources/Services/TokenService.swift
@@ -1,14 +1,16 @@
 final class TokenService {
     static func createTokenEndpoint(
+        storageService: StorageService? = nil,
         completion: @escaping (Result<TokenEndpoint, Error>) -> Void
     ) {
         do {
-            guard let appKey = try ServiceContainer.shared.storageService.getAppId() else {
+            let storage = storageService ?? ServiceContainer.shared.storageService
+            guard let appKey = try storage.getAppId() else {
                 completion(.failure(DatabaseErrorType.missingAppKey))
                 return
             }
 
-            guard let consumerId = try ServiceContainer.shared.storageService.getConsumerId() else {
+            guard let consumerId = try storage.getConsumerId() else {
                 completion(.failure(DatabaseErrorType.missingConsumerId))
                 return
             }

--- a/AppAmbitSdk/Sources/Utils/DecoderUtils.swift
+++ b/AppAmbitSdk/Sources/Utils/DecoderUtils.swift
@@ -241,7 +241,7 @@ private struct FlexibleSingleValueContainer: SingleValueDecodingContainer {
 
 // MARK: - JSON Handling
 
-public enum JSONValue: Codable, @unchecked Sendable {
+public enum JSONValue: Codable, Equatable, @unchecked Sendable {
     case string(String)
     case int(Int)
     case double(Double)

--- a/AppAmbitSdk/Sources/Utils/URLQueryBuilder.swift
+++ b/AppAmbitSdk/Sources/Utils/URLQueryBuilder.swift
@@ -1,13 +1,14 @@
 import Foundation
 
 enum URLQueryBuilder {
+    private static let allowedQueryCharacters = CharacterSet.alphanumerics.union(.init(charactersIn: "-._~"))
+
     static func append(query: [String: String]?, toPath path: String) -> String {
         guard let query, !query.isEmpty else { return path }
 
-        var components = URLComponents()
-        components.percentEncodedPath = path
-        components.queryItems = queryItems(from: query)
-        return components.string ?? path
+        let queryString = percentEncodedQuery(from: query)
+        guard !queryString.isEmpty else { return path }
+        return path + (path.contains("?") ? "&" : "?") + queryString
     }
 
     static func queryItems(from query: [String: String]) -> [URLQueryItem] {
@@ -20,5 +21,22 @@ enum URLQueryBuilder {
         dictionary.keys.sorted().map { key in
             URLQueryItem(name: key, value: String(describing: dictionary[key]!))
         }
+    }
+
+    static func percentEncodedQuery(from query: [String: String]) -> String {
+        query.keys.sorted().compactMap { key in
+            guard let value = query[key] else { return nil }
+            return "\(encode(key))=\(encode(value))"
+        }.joined(separator: "&")
+    }
+
+    static func percentEncodedQuery(from dictionary: [String: Any]) -> String {
+        dictionary.keys.sorted().map { key in
+            "\(encode(key))=\(encode(String(describing: dictionary[key]!)))"
+        }.joined(separator: "&")
+    }
+
+    private static func encode(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: allowedQueryCharacters) ?? value
     }
 }

--- a/AppAmbitSdk/Sources/Utils/URLQueryBuilder.swift
+++ b/AppAmbitSdk/Sources/Utils/URLQueryBuilder.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum URLQueryBuilder {
+    static func append(query: [String: String]?, toPath path: String) -> String {
+        guard let query, !query.isEmpty else { return path }
+
+        var components = URLComponents()
+        components.percentEncodedPath = path
+        components.queryItems = queryItems(from: query)
+        return components.string ?? path
+    }
+
+    static func queryItems(from query: [String: String]) -> [URLQueryItem] {
+        query.keys.sorted().map { key in
+            URLQueryItem(name: key, value: query[key])
+        }
+    }
+
+    static func queryItems(from dictionary: [String: Any]) -> [URLQueryItem] {
+        dictionary.keys.sorted().map { key in
+            URLQueryItem(name: key, value: String(describing: dictionary[key]!))
+        }
+    }
+}

--- a/AppAmbitSdk/Tests/CloudCodeTests.swift
+++ b/AppAmbitSdk/Tests/CloudCodeTests.swift
@@ -819,7 +819,7 @@ final class CloudCodeTests: XCTestCase {
         XCTAssertEqual(requestCapture.requests.filter { $0.url?.path.hasSuffix("/consumer/token") == true }.count, 1)
     }
 
-    func testCloudCodeGatewayDoesNotRetryMutatingMethodsAfter401() throws {
+    func testCloudCodeGatewayRetriesMutatingMethodsAfter401() throws {
         let requestCapture = RequestCapture()
         TestURLProtocol.requestHandler = { request in
             requestCapture.append(request)
@@ -834,13 +834,24 @@ final class CloudCodeTests: XCTestCase {
                 )!
                 body = Data("{\"id\":123,\"token\":\"fresh-token\"}".utf8)
             } else {
-                response = HTTPURLResponse(
-                    url: try XCTUnwrap(request.url),
-                    statusCode: 401,
-                    httpVersion: nil,
-                    headerFields: ["X-Request-Id": "mutation-unauthorized"]
-                )!
-                body = Data("{\"error\":\"expired\"}".utf8)
+                let requestCount = requestCapture.requests.filter { $0.url == request.url }.count
+                if requestCount == 1 {
+                    response = HTTPURLResponse(
+                        url: try XCTUnwrap(request.url),
+                        statusCode: 401,
+                        httpVersion: nil,
+                        headerFields: ["X-Request-Id": "mutation-unauthorized"]
+                    )!
+                    body = Data("{\"error\":\"expired\"}".utf8)
+                } else {
+                    response = HTTPURLResponse(
+                        url: try XCTUnwrap(request.url),
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: ["X-Request-Id": "mutation-retried"]
+                    )!
+                    body = Data("{\"ok\":true}".utf8)
+                }
             }
             return (response, body)
         }
@@ -873,16 +884,13 @@ final class CloudCodeTests: XCTestCase {
                 )
             }
 
-            guard case .http(let statusCode, _, _, let requestId) = error as? CloudCodeError else {
-                return XCTFail("Expected HTTP 401 for \(method), got \(String(describing: error))")
-            }
-            XCTAssertNil(response)
-            XCTAssertEqual(statusCode, 401)
-            XCTAssertEqual(requestId, "mutation-unauthorized")
+            XCTAssertNil(error)
+            XCTAssertEqual(response?.statusCode, 200)
+            XCTAssertEqual(response?.data as? [String: Bool], ["ok": true])
         }
 
-        XCTAssertEqual(requestCapture.requests.filter { $0.url?.path.contains("/fn/") == true }.count, 3)
-        XCTAssertEqual(requestCapture.requests.filter { $0.url?.path.hasSuffix("/consumer/token") == true }.count, 0)
+        XCTAssertEqual(requestCapture.requests.filter { $0.url?.path.contains("/fn/") == true }.count, 6)
+        XCTAssertEqual(requestCapture.requests.filter { $0.url?.path.hasSuffix("/consumer/token") == true }.count, 3)
     }
 
     func testConcurrentCloudCode401RequestsShareOneTokenRenewal() throws {

--- a/AppAmbitSdk/Tests/CloudCodeTests.swift
+++ b/AppAmbitSdk/Tests/CloudCodeTests.swift
@@ -37,6 +37,18 @@ final class CloudCodeTests: XCTestCase {
         XCTAssertEqual(endpoint.payload as? [String: Int], ["count": 2])
     }
 
+    func testEndpointPercentEncodesPlusInQueryValues() {
+        let endpoint = CloudCodeEndpoint(
+            function: "search",
+            method: .get,
+            query: ["email": "user+test@example.com"],
+            body: nil,
+            headers: nil
+        )
+
+        XCTAssertEqual(endpoint.url, "/fn/search?email=user%2Btest%40example.com")
+    }
+
     func testHttpMethodsAreMappedToApiMethods() {
         XCTAssertEqual(CloudCodeHttpMethod.get.apiMethod, .get)
         XCTAssertEqual(CloudCodeHttpMethod.post.apiMethod, .post)
@@ -98,6 +110,37 @@ final class CloudCodeTests: XCTestCase {
         }
         XCTAssertEqual(header, "authorization")
         XCTAssertEqual(transport.requestCount, 0)
+    }
+
+    func testTracingHeadersAreAcceptedAsBusinessHeaders() {
+        let transport = TestCloudCodeTransport()
+        transport.response = CloudCodeTransportResponse(
+            statusCode: 200,
+            data: Data("{}".utf8),
+            headers: [:],
+            error: nil
+        )
+        let service = CloudCodeService(transport: transport)
+
+        let (response, error) = waitForUntyped { completion in
+            service.call(
+                function: "traceable",
+                method: .get,
+                query: nil,
+                body: nil,
+                headers: [
+                    "X-Trace-Id": "trace",
+                    "traceparent": "parent",
+                    "X-AppAmbit-Correlation": "correlation",
+                    "X-Internal-Test": "internal"
+                ],
+                completion: completion
+            )
+        }
+
+        XCTAssertNil(error)
+        XCTAssertNotNil(response)
+        XCTAssertEqual(transport.requestCount, 1)
     }
 
     func testDefaultTimeoutIsSixtySecondsAndCustomRequestDataIsForwarded() {
@@ -174,6 +217,51 @@ final class CloudCodeTests: XCTestCase {
         }
     }
 
+    func testHTTPErrorBridgesStructuredMetadataToNSError() {
+        let error = CloudCodeError.http(
+            statusCode: 404,
+            body: .object(["error": .string("not_found")]),
+            rawBody: nil,
+            requestId: "error-id"
+        ) as NSError
+
+        XCTAssertEqual(error.domain, CloudCodeError.errorDomain)
+        XCTAssertEqual(error.code, 10)
+        XCTAssertEqual(error.userInfo[CloudCodeErrorKeys.statusCode] as? Int, 404)
+        XCTAssertEqual(
+            (error.userInfo[CloudCodeErrorKeys.body] as? [String: Any])?["error"] as? String,
+            "not_found"
+        )
+        XCTAssertEqual(error.userInfo[CloudCodeErrorKeys.requestId] as? String, "error-id")
+    }
+
+    func testEmptySuccessfulBodyMapsToNSNullForUntypedResponse() {
+        let transport = TestCloudCodeTransport()
+        transport.response = CloudCodeTransportResponse(
+            statusCode: 200,
+            data: nil,
+            headers: ["X-Request-Id": "empty-body-id"],
+            error: nil
+        )
+        let service = CloudCodeService(transport: transport)
+
+        let (response, error) = waitForUntyped { completion in
+            service.call(
+                function: "empty-body",
+                method: .get,
+                query: nil,
+                body: nil,
+                headers: nil,
+                completion: completion
+            )
+        }
+
+        XCTAssertNil(error)
+        XCTAssertTrue(response?.data is NSNull)
+        XCTAssertEqual(response?.statusCode, 200)
+        XCTAssertEqual(response?.requestId, "empty-body-id")
+    }
+
     func testTypedResultAndRequestIdFallbackArePreserved() {
         struct Greeting: Decodable, Equatable {
             let greeting: String
@@ -234,8 +322,80 @@ final class CloudCodeTests: XCTestCase {
         }
 
         wait(for: [expectation], timeout: 2)
-        XCTAssertNil(resultBox.value)
+        XCTAssertNil(resultBox.value?.data)
+        XCTAssertEqual(resultBox.value?.statusCode, 204)
+        XCTAssertEqual(resultBox.value?.requestId, "empty-id")
+        XCTAssertEqual(resultBox.value?.headers["X-Request-Id"], "empty-id")
         XCTAssertNil(resultBox.error)
+    }
+
+    func testTypedEmptySuccessfulBodyCompletesWithNilDataAndMetadata() {
+        let transport = TestCloudCodeTransport()
+        transport.response = CloudCodeTransportResponse(
+            statusCode: 200,
+            data: nil,
+            headers: ["X-Request-Id": "empty-body-id"],
+            error: nil
+        )
+        let service = CloudCodeService(transport: transport)
+        let expectation = expectation(description: "typed empty result")
+        let resultBox = ResultBox<CloudCodeResult<String>, CloudCodeError>()
+
+        service.call(
+            function: "empty-body",
+            method: .get,
+            query: nil,
+            body: nil,
+            headers: nil,
+            as: String.self
+        ) { receivedResult, receivedError in
+            resultBox.set(receivedResult, receivedError)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2)
+        XCTAssertNil(resultBox.value?.data)
+        XCTAssertEqual(resultBox.value?.statusCode, 200)
+        XCTAssertEqual(resultBox.value?.requestId, "empty-body-id")
+        XCTAssertEqual(resultBox.value?.headers["X-Request-Id"], "empty-body-id")
+        XCTAssertNil(resultBox.error)
+    }
+
+    func testCallbacksAreDeliveredOnMainQueue() {
+        let transport = TestCloudCodeTransport()
+        transport.response = CloudCodeTransportResponse(
+            statusCode: 200,
+            data: Data("{}".utf8),
+            headers: [:],
+            error: nil
+        )
+        let service = CloudCodeService(transport: transport)
+        let validationExpectation = expectation(description: "validation callback on main")
+        let transportExpectation = expectation(description: "transport callback on main")
+
+        service.call(
+            function: "invalid/function",
+            method: .get,
+            query: nil,
+            body: nil,
+            headers: nil
+        ) { _, _ in
+            XCTAssertTrue(Thread.isMainThread)
+            validationExpectation.fulfill()
+        }
+
+        service.call(
+            function: "valid",
+            method: .get,
+            query: nil,
+            body: nil,
+            headers: nil
+        ) { _, _ in
+            XCTAssertTrue(Thread.isMainThread)
+            transportExpectation.fulfill()
+        }
+
+        wait(for: [validationExpectation, transportExpectation], timeout: 2)
     }
 
     func testTransportErrorsKeepTheirMeaning() {
@@ -419,7 +579,8 @@ final class CloudCodeTests: XCTestCase {
         let requests = requestCapture.requests
         XCTAssertEqual(requests.count, 2)
         XCTAssertEqual(requests[0].httpMethod, "GET")
-        XCTAssertNil(requests[0].httpBody)
+        XCTAssertTrue(try requestBodyData(from: requests[0])?.isEmpty ?? true)
+        XCTAssertNil(requests[0].value(forHTTPHeaderField: "Content-Type"))
         XCTAssertEqual(requests[0].value(forHTTPHeaderField: "X-Test"), "get")
         XCTAssertEqual(
             URLComponents(url: try XCTUnwrap(requests[0].url), resolvingAgainstBaseURL: false)?.queryItems,
@@ -430,9 +591,261 @@ final class CloudCodeTests: XCTestCase {
         XCTAssertEqual(requests[1].value(forHTTPHeaderField: "X-Test"), "delete")
         XCTAssertEqual(requests[1].value(forHTTPHeaderField: "Content-Type"), "application/json")
         XCTAssertEqual(
-            try JSONSerialization.jsonObject(with: try XCTUnwrap(requests[1].httpBody)) as? [String: Bool],
+            try JSONSerialization.jsonObject(with: try XCTUnwrap(requestBodyData(from: requests[1]))) as? [String: Bool],
             ["keep": true]
         )
+    }
+
+    func testCloudCodeGatewayRefreshesAfter401AndRetriesOnce() throws {
+        let requestCapture = RequestCapture()
+        TestURLProtocol.requestHandler = { request in
+            requestCapture.append(request)
+            let path = request.url?.path ?? ""
+            let cloudRequests = requestCapture.requests.filter { $0.url?.path.hasSuffix("/fn/retry") == true }
+            let response: HTTPURLResponse
+            let body: Data
+
+            if path.hasSuffix("/consumer/token") {
+                response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                body = Data("{\"id\":123,\"token\":\"fresh-token\"}".utf8)
+            } else if cloudRequests.count == 1 {
+                response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 401,
+                    httpVersion: nil,
+                    headerFields: ["X-Request-Id": "first-unauthorized"]
+                )!
+                body = Data("{\"error\":\"expired\"}".utf8)
+            } else {
+                response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["X-Request-Id": "retried"]
+                )!
+                body = Data("{\"ok\":true}".utf8)
+            }
+            return (response, body)
+        }
+        defer { TestURLProtocol.reset() }
+
+        let storage = InMemoryStorage()
+        try storage.putAppId("test-app")
+        try storage.putConsumerId("test-consumer")
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [TestURLProtocol.self]
+        let apiService = AppAmbitApiService(
+            storageService: storage,
+            urlSession: URLSession(configuration: configuration),
+            isConnected: { true }
+        )
+        apiService.setToken("stale-token")
+        let service = CloudCodeService(transport: apiService)
+
+        let (response, error) = waitForUntyped { completion in
+            service.call(
+                function: "retry",
+                method: .get,
+                query: nil,
+                body: nil,
+                headers: nil,
+                completion: completion
+            )
+        }
+
+        let cloudRequests = requestCapture.requests.filter { $0.url?.path.hasSuffix("/fn/retry") == true }
+        XCTAssertNil(error)
+        XCTAssertEqual(response?.statusCode, 200)
+        XCTAssertEqual(response?.data as? [String: Bool], ["ok": true])
+        XCTAssertEqual(cloudRequests.count, 2)
+        XCTAssertEqual(cloudRequests[0].value(forHTTPHeaderField: "Authorization"), "Bearer stale-token")
+        XCTAssertEqual(cloudRequests[1].value(forHTTPHeaderField: "Authorization"), "Bearer fresh-token")
+        XCTAssertEqual(requestCapture.requests.filter { $0.url?.path.hasSuffix("/consumer/token") == true }.count, 1)
+    }
+
+    func testCloudCodeGatewayStopsAfterSecond401() throws {
+        let requestCapture = RequestCapture()
+        TestURLProtocol.requestHandler = { request in
+            requestCapture.append(request)
+            let response: HTTPURLResponse
+            let body: Data
+            if request.url?.path.hasSuffix("/consumer/token") == true {
+                response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                body = Data("{\"id\":123,\"token\":\"fresh-token\"}".utf8)
+            } else {
+                response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 401,
+                    httpVersion: nil,
+                    headerFields: ["X-Request-Id": "still-unauthorized"]
+                )!
+                body = Data("{\"error\":\"unauthorized\"}".utf8)
+            }
+            return (response, body)
+        }
+        defer { TestURLProtocol.reset() }
+
+        let storage = InMemoryStorage()
+        try storage.putAppId("test-app")
+        try storage.putConsumerId("test-consumer")
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [TestURLProtocol.self]
+        let apiService = AppAmbitApiService(
+            storageService: storage,
+            urlSession: URLSession(configuration: configuration),
+            isConnected: { true }
+        )
+        apiService.setToken("stale-token")
+        let service = CloudCodeService(transport: apiService)
+
+        let (response, error) = waitForUntyped { completion in
+            service.call(
+                function: "retry-failure",
+                method: .get,
+                query: nil,
+                body: nil,
+                headers: nil,
+                completion: completion
+            )
+        }
+
+        let cloudRequests = requestCapture.requests.filter { $0.url?.path.hasSuffix("/fn/retry-failure") == true }
+        guard case .http(let statusCode, _, _, let requestId) = error as? CloudCodeError else {
+            return XCTFail("Expected second HTTP 401, got \(String(describing: error))")
+        }
+        XCTAssertNil(response)
+        XCTAssertEqual(statusCode, 401)
+        XCTAssertEqual(requestId, "still-unauthorized")
+        XCTAssertEqual(cloudRequests.count, 2)
+        XCTAssertEqual(requestCapture.requests.filter { $0.url?.path.hasSuffix("/consumer/token") == true }.count, 1)
+    }
+
+    func testConcurrentCloudCode401RequestsShareOneTokenRenewal() throws {
+        let requestCapture = RequestCapture()
+        let firstUnauthorizedResponses = DispatchSemaphore(value: 0)
+        TestURLProtocol.requestHandler = { request in
+            requestCapture.append(request)
+            let path = request.url?.path ?? ""
+            let pathRequests = requestCapture.requests.filter { $0.url?.path == path }
+            let response: HTTPURLResponse
+            let body: Data
+
+            if path.hasSuffix("/consumer/token") {
+                _ = firstUnauthorizedResponses.wait(timeout: .now() + 2)
+                response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                body = Data("{\"id\":123,\"token\":\"shared-token\"}".utf8)
+            } else if pathRequests.count == 1 {
+                firstUnauthorizedResponses.signal()
+                response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 401,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                body = Data("{\"error\":\"expired\"}".utf8)
+            } else {
+                response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                body = Data("{\"ok\":true}".utf8)
+            }
+            return (response, body)
+        }
+        defer { TestURLProtocol.reset() }
+
+        let storage = InMemoryStorage()
+        try storage.putAppId("test-app")
+        try storage.putConsumerId("test-consumer")
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [TestURLProtocol.self]
+        let apiService = AppAmbitApiService(
+            storageService: storage,
+            urlSession: URLSession(configuration: configuration),
+            isConnected: { true }
+        )
+        apiService.setToken("stale-token")
+        let service = CloudCodeService(transport: apiService)
+        let firstResult = ResultBox<CloudCodeResponse, Error>()
+        let secondResult = ResultBox<CloudCodeResponse, Error>()
+        let firstExpectation = expectation(description: "first concurrent result")
+        let secondExpectation = expectation(description: "second concurrent result")
+
+        DispatchQueue.global().async {
+            service.call(
+                function: "concurrent-one",
+                method: .get,
+                query: nil,
+                body: nil,
+                headers: nil
+            ) { response, error in
+                firstResult.set(response, error)
+                firstExpectation.fulfill()
+            }
+        }
+        DispatchQueue.global().async {
+            service.call(
+                function: "concurrent-two",
+                method: .get,
+                query: nil,
+                body: nil,
+                headers: nil
+            ) { response, error in
+                secondResult.set(response, error)
+                secondExpectation.fulfill()
+            }
+        }
+
+        wait(for: [firstExpectation, secondExpectation], timeout: 5)
+
+        XCTAssertNil(firstResult.error)
+        XCTAssertNil(secondResult.error)
+        XCTAssertEqual(firstResult.value?.data as? [String: Bool], ["ok": true])
+        XCTAssertEqual(secondResult.value?.data as? [String: Bool], ["ok": true])
+        XCTAssertEqual(requestCapture.requests.filter { $0.url?.path.hasSuffix("/consumer/token") == true }.count, 1)
+        XCTAssertEqual(requestCapture.requests.filter { $0.url?.path.hasSuffix("/fn/concurrent-one") == true }.count, 2)
+        XCTAssertEqual(requestCapture.requests.filter { $0.url?.path.hasSuffix("/fn/concurrent-two") == true }.count, 2)
+    }
+
+    private func requestBodyData(from request: URLRequest) throws -> Data? {
+        if let body = request.httpBody {
+            return body
+        }
+
+        guard let stream = request.httpBodyStream else { return nil }
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count > 0 {
+                data.append(buffer, count: count)
+            } else if count == 0 {
+                break
+            } else {
+                throw stream.streamError ?? NSError(domain: "CloudCodeTests", code: 1)
+            }
+        }
+        return data
     }
 
     private func waitForRawResponse(_ apiService: AppAmbitApiService, endpoint: Endpoint) -> HTTPTransportResponse {

--- a/AppAmbitSdk/Tests/CloudCodeTests.swift
+++ b/AppAmbitSdk/Tests/CloudCodeTests.swift
@@ -1,0 +1,436 @@
+import Foundation
+import XCTest
+@testable import AppAmbit
+
+final class CloudCodeTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        CloudCode.resetForTesting()
+    }
+
+    override func tearDown() {
+        CloudCode.resetForTesting()
+        super.tearDown()
+    }
+
+    func testCallBeforeAppAmbitStartReturnsNotInitialized() {
+        let (response, error) = waitForUntyped { completion in
+            CloudCode.call("hello", completion: completion)
+        }
+
+        XCTAssertNil(response)
+        XCTAssertEqual(error as? CloudCodeError, .notInitialized)
+    }
+
+    func testEndpointEncodesFunctionAndQueryAsURLComponents() {
+        let endpoint = CloudCodeEndpoint(
+            function: "hello world?",
+            method: .post,
+            query: ["source": "swift", "message": "hello world"],
+            body: ["count": 2],
+            headers: ["X-Trace": "test"]
+        )
+
+        XCTAssertEqual(endpoint.url, "/fn/hello%20world%3F?message=hello%20world&source=swift")
+        XCTAssertEqual(endpoint.method, .post)
+        XCTAssertEqual(endpoint.customHeader?["X-Trace"], "test")
+        XCTAssertEqual(endpoint.payload as? [String: Int], ["count": 2])
+    }
+
+    func testHttpMethodsAreMappedToApiMethods() {
+        XCTAssertEqual(CloudCodeHttpMethod.get.apiMethod, .get)
+        XCTAssertEqual(CloudCodeHttpMethod.post.apiMethod, .post)
+        XCTAssertEqual(CloudCodeHttpMethod.put.apiMethod, .put)
+        XCTAssertEqual(CloudCodeHttpMethod.patch.apiMethod, .patch)
+        XCTAssertEqual(CloudCodeHttpMethod.delete.apiMethod, .delete)
+    }
+
+    func testInvalidFunctionIsRejectedBeforeTransport() {
+        let transport = TestCloudCodeTransport()
+        let service = CloudCodeService(transport: transport)
+
+        let (_, error) = waitForUntyped { completion in
+            service.call(
+                function: "invalid/function",
+                method: .post,
+                query: nil,
+                body: nil,
+                headers: nil,
+                completion: completion
+            )
+        }
+
+        guard case .invalidFunction(let function) = error as? CloudCodeError else {
+            return XCTFail("Expected invalidFunction, got \(String(describing: error))")
+        }
+        XCTAssertEqual(function, "invalid/function")
+        XCTAssertEqual(transport.requestCount, 0)
+    }
+
+    func testInvalidBodyAndReservedHeadersAreRejectedBeforeTransport() {
+        let transport = TestCloudCodeTransport()
+        let service = CloudCodeService(transport: transport)
+
+        let (_, bodyError) = waitForUntyped { completion in
+            service.call(
+                function: "hello",
+                method: .post,
+                query: nil,
+                body: ["date": Date()],
+                headers: nil,
+                completion: completion
+            )
+        }
+        XCTAssertEqual(bodyError as? CloudCodeError, .invalidBody)
+
+        let (_, headerError) = waitForUntyped { completion in
+            service.call(
+                function: "hello",
+                method: .post,
+                query: nil,
+                body: nil,
+                headers: ["authorization": "spoofed"],
+                completion: completion
+            )
+        }
+        guard case .invalidHeader(let header) = headerError as? CloudCodeError else {
+            return XCTFail("Expected invalidHeader, got \(String(describing: headerError))")
+        }
+        XCTAssertEqual(header, "authorization")
+        XCTAssertEqual(transport.requestCount, 0)
+    }
+
+    func testDefaultTimeoutIsSixtySecondsAndCustomRequestDataIsForwarded() {
+        let transport = TestCloudCodeTransport()
+        let service = CloudCodeService(transport: transport)
+
+        transport.response = CloudCodeTransportResponse(
+            statusCode: 200,
+            data: Data("{\"ok\":true}".utf8),
+            headers: [:],
+            error: nil
+        )
+
+        let (response, error) = waitForUntyped { completion in
+            service.call(
+                function: "hello",
+                method: .patch,
+                query: ["source": "ios"],
+                body: ["message": "hello"],
+                headers: ["X-Trace": "test"],
+                completion: completion
+            )
+        }
+
+        XCTAssertNil(error)
+        XCTAssertEqual(response?.statusCode, 200)
+        XCTAssertEqual(response?.data as? [String: Bool], ["ok": true])
+        XCTAssertEqual(transport.lastTimeout, 60)
+        XCTAssertEqual(transport.lastEndpoint?.method, .patch)
+        XCTAssertEqual(transport.lastEndpoint?.url, "/fn/hello?source=ios")
+        XCTAssertEqual(transport.requestCount, 1)
+    }
+
+    func testAllJSONResultShapesAreSupported() {
+        let payloads = [
+            "{\"ok\":true}",
+            "[1,\"two\",true]",
+            "\"hello\"",
+            "7",
+            "true",
+            "null"
+        ]
+
+        for payload in payloads {
+            let transport = TestCloudCodeTransport()
+            transport.response = CloudCodeTransportResponse(
+                statusCode: 200,
+                data: Data(payload.utf8),
+                headers: [:],
+                error: nil
+            )
+            let service = CloudCodeService(transport: transport)
+
+            let (response, error) = waitForUntyped { completion in
+                service.call(
+                    function: "json-values",
+                    method: .post,
+                    query: nil,
+                    body: nil,
+                    headers: nil,
+                    completion: completion
+                )
+            }
+
+            XCTAssertNil(error, payload)
+            XCTAssertNotNil(response, payload)
+            switch payload {
+            case "\"hello\"": XCTAssertTrue(response?.data is String)
+            case "7": XCTAssertTrue(response?.data is Int)
+            case "true": XCTAssertTrue(response?.data is Bool)
+            case "null": XCTAssertTrue(response?.data is NSNull)
+            default: break
+            }
+        }
+    }
+
+    func testTypedResultAndRequestIdFallbackArePreserved() {
+        struct Greeting: Decodable, Equatable {
+            let greeting: String
+        }
+
+        let transport = TestCloudCodeTransport()
+        transport.response = CloudCodeTransportResponse(
+            statusCode: 201,
+            data: Data("{\"greeting\":\"hello\",\"request_id\":\"body-id\"}".utf8),
+            headers: [:],
+            error: nil
+        )
+        let service = CloudCodeService(transport: transport)
+
+        let resultBox = ResultBox<CloudCodeResult<Greeting>, CloudCodeError>()
+        let expectation = expectation(description: "typed result")
+        service.call(
+            function: "typed",
+            method: .post,
+            query: nil,
+            body: nil,
+            headers: nil,
+            as: Greeting.self
+        ) { result, error in
+            resultBox.set(result, error)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2)
+
+        XCTAssertNil(resultBox.error)
+        XCTAssertEqual(resultBox.value?.data, Greeting(greeting: "hello"))
+        XCTAssertEqual(resultBox.value?.statusCode, 201)
+        XCTAssertEqual(resultBox.value?.requestId, "body-id")
+    }
+
+    func testTyped204CompletesWithoutDecodingError() {
+        let transport = TestCloudCodeTransport()
+        transport.response = CloudCodeTransportResponse(
+            statusCode: 204,
+            data: nil,
+            headers: ["X-Request-Id": "empty-id"],
+            error: nil
+        )
+        let service = CloudCodeService(transport: transport)
+        let expectation = expectation(description: "typed 204 result")
+        let resultBox = ResultBox<CloudCodeResult<String>, CloudCodeError>()
+
+        service.call(
+            function: "empty",
+            method: .delete,
+            query: nil,
+            body: nil,
+            headers: nil,
+            as: String.self
+        ) { receivedResult, receivedError in
+            resultBox.set(receivedResult, receivedError)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 2)
+        XCTAssertNil(resultBox.value)
+        XCTAssertNil(resultBox.error)
+    }
+
+    func testTransportErrorsKeepTheirMeaning() {
+        let cases: [(Error, CloudCodeError)] = [
+            (URLError(.notConnectedToInternet), .networkUnavailable),
+            (URLError(.networkConnectionLost), .networkUnavailable),
+            (URLError(.timedOut), .timedOut),
+            (ApiExceptions.invalidURL, .invalidURL)
+        ]
+
+        for (transportError, expectedError) in cases {
+            let transport = TestCloudCodeTransport()
+            transport.response = CloudCodeTransportResponse(
+                statusCode: nil,
+                data: nil,
+                headers: [:],
+                error: transportError
+            )
+            let service = CloudCodeService(transport: transport)
+            let (_, error) = waitForUntyped { completion in
+                service.call(
+                    function: "transport-error",
+                    method: .get,
+                    query: nil,
+                    body: nil,
+                    headers: nil,
+                    completion: completion
+                )
+            }
+            XCTAssertEqual(error as? CloudCodeError, expectedError)
+        }
+    }
+
+    func testHeaderRequestIdTakesPriorityOverBodyRequestId() {
+        let transport = TestCloudCodeTransport()
+        transport.response = CloudCodeTransportResponse(
+            statusCode: 200,
+            data: Data("{\"request_id\":\"body-id\"}".utf8),
+            headers: ["x-request-id": "header-id"],
+            error: nil
+        )
+        let service = CloudCodeService(transport: transport)
+
+        let (response, error) = waitForUntyped { completion in
+            service.call(
+                function: "request-id",
+                method: .get,
+                query: nil,
+                body: nil,
+                headers: nil,
+                completion: completion
+            )
+        }
+
+        XCTAssertNil(error)
+        XCTAssertEqual(response?.requestId, "header-id")
+    }
+
+    func testHTTPErrorsPreserveStatusBodyAndRequestId() {
+        for statusCode in [400, 401, 402, 404, 429, 500, 503, 504] {
+            let transport = TestCloudCodeTransport()
+            transport.response = CloudCodeTransportResponse(
+                statusCode: statusCode,
+                data: Data("{\"error\":\"failed\",\"request_id\":\"error-id\"}".utf8),
+                headers: [:],
+                error: nil
+            )
+            let service = CloudCodeService(transport: transport)
+
+            let (_, error) = waitForUntyped { completion in
+                service.call(
+                    function: "error",
+                    method: .post,
+                    query: nil,
+                    body: nil,
+                    headers: nil,
+                    completion: completion
+                )
+            }
+
+            guard case .http(let actualStatus, let body, _, let requestId) = error as? CloudCodeError else {
+                return XCTFail("Expected HTTP error for status \(statusCode), got \(String(describing: error))")
+            }
+            XCTAssertEqual(actualStatus, statusCode)
+            XCTAssertEqual(body, .object(["error": .string("failed"), "request_id": .string("error-id")]))
+            XCTAssertEqual(requestId, "error-id")
+        }
+    }
+
+    func testNoCallbackAfterCancellation() {
+        let transport = TestCloudCodeTransport()
+        let service = CloudCodeService(transport: transport)
+        let callbackExpectation = expectation(description: "callback is suppressed")
+        callbackExpectation.isInverted = true
+
+        let token = service.call(
+            function: "slow",
+            method: .post,
+            query: nil,
+            body: nil,
+            headers: nil
+        ) { _, _ in
+            callbackExpectation.fulfill()
+        }
+
+        token.cancel()
+        transport.deliver(CloudCodeTransportResponse(
+            statusCode: 200,
+            data: Data("{\"ok\":true}".utf8),
+            headers: [:],
+            error: nil
+        ))
+        wait(for: [callbackExpectation], timeout: 0.2)
+    }
+
+    func testFacadeUsesInitializedCloudCodeService() {
+        let transport = TestCloudCodeTransport()
+        transport.response = CloudCodeTransportResponse(
+            statusCode: 200,
+            data: Data("{\"ok\":true}".utf8),
+            headers: [:],
+            error: nil
+        )
+        CloudCode.initialize(service: CloudCodeService(transport: transport))
+
+        let (response, error) = waitForUntyped { completion in
+            CloudCode.call("hello", completion: completion)
+        }
+
+        XCTAssertNil(error)
+        XCTAssertEqual(response?.statusCode, 200)
+        XCTAssertEqual(transport.requestCount, 1)
+    }
+
+    private func waitForUntyped(
+        _ start: (@escaping @Sendable (CloudCodeResponse?, Error?) -> Void) -> Void
+    ) -> (CloudCodeResponse?, Error?) {
+        let expectation = expectation(description: "Cloud Code response")
+        let box = ResultBox<CloudCodeResponse, Error>()
+        start { response, error in
+            box.set(response, error)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2)
+        return (box.value, box.error)
+    }
+}
+
+private final class TestCloudCodeTransport: CloudCodeTransport, @unchecked Sendable {
+    private let lock = NSLock()
+    private var pendingCompletion: (@Sendable (CloudCodeTransportResponse) -> Void)?
+
+    var response: CloudCodeTransportResponse?
+    private(set) var requestCount = 0
+    private(set) var lastTimeout: TimeInterval?
+    private(set) var lastEndpoint: CloudCodeEndpoint?
+
+    func executeCloudCodeRequest(
+        _ endpoint: CloudCodeEndpoint,
+        timeout: TimeInterval,
+        completion: @escaping @Sendable (CloudCodeTransportResponse) -> Void
+    ) {
+        lock.lock()
+        requestCount += 1
+        lastTimeout = timeout
+        lastEndpoint = endpoint
+        let response = response
+        if response == nil {
+            pendingCompletion = completion
+        }
+        lock.unlock()
+
+        if let response {
+            completion(response)
+        }
+    }
+
+    func deliver(_ response: CloudCodeTransportResponse) {
+        lock.lock()
+        let completion = pendingCompletion
+        pendingCompletion = nil
+        lock.unlock()
+        completion?(response)
+    }
+}
+
+private final class ResultBox<Value, Failure: Error>: @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var value: Value?
+    private(set) var error: Failure?
+
+    func set(_ value: Value?, _ error: Failure?) {
+        lock.lock()
+        self.value = value
+        self.error = error
+        lock.unlock()
+    }
+}

--- a/AppAmbitSdk/Tests/CloudCodeTests.swift
+++ b/AppAmbitSdk/Tests/CloudCodeTests.swift
@@ -370,6 +370,82 @@ final class CloudCodeTests: XCTestCase {
         XCTAssertEqual(transport.requestCount, 1)
     }
 
+    func testSharedTransportOmitsCloudCodeGETBodyAndPreservesDELETEBody() throws {
+        let requestCapture = RequestCapture()
+        TestURLProtocol.requestHandler = { request in
+            requestCapture.append(request)
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["X-Request-Id": "raw-id"]
+            )!
+            return (response, Data("{\"ok\":true}".utf8))
+        }
+        defer { TestURLProtocol.reset() }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [TestURLProtocol.self]
+        let apiService = AppAmbitApiService(
+            storageService: InMemoryStorage(),
+            urlSession: URLSession(configuration: configuration),
+            isConnected: { true }
+        )
+
+        let getEndpoint = CloudCodeEndpoint(
+            function: "get-function",
+            method: .get,
+            query: ["message": "hello world"],
+            body: ["ignored": true],
+            headers: ["X-Test": "get"]
+        )
+        getEndpoint.skipAuthorization = true
+        let getResponse = waitForRawResponse(apiService, endpoint: getEndpoint)
+
+        let deleteEndpoint = CloudCodeEndpoint(
+            function: "delete-function",
+            method: .delete,
+            query: nil,
+            body: ["keep": true],
+            headers: ["X-Test": "delete"]
+        )
+        deleteEndpoint.skipAuthorization = true
+        let deleteResponse = waitForRawResponse(apiService, endpoint: deleteEndpoint)
+
+        XCTAssertEqual(getResponse.statusCode, 200)
+        XCTAssertEqual(getResponse.headers["X-Request-Id"], "raw-id")
+        XCTAssertEqual(deleteResponse.statusCode, 200)
+
+        let requests = requestCapture.requests
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(requests[0].httpMethod, "GET")
+        XCTAssertNil(requests[0].httpBody)
+        XCTAssertEqual(requests[0].value(forHTTPHeaderField: "X-Test"), "get")
+        XCTAssertEqual(
+            URLComponents(url: try XCTUnwrap(requests[0].url), resolvingAgainstBaseURL: false)?.queryItems,
+            [URLQueryItem(name: "message", value: "hello world")]
+        )
+
+        XCTAssertEqual(requests[1].httpMethod, "DELETE")
+        XCTAssertEqual(requests[1].value(forHTTPHeaderField: "X-Test"), "delete")
+        XCTAssertEqual(requests[1].value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertEqual(
+            try JSONSerialization.jsonObject(with: try XCTUnwrap(requests[1].httpBody)) as? [String: Bool],
+            ["keep": true]
+        )
+    }
+
+    private func waitForRawResponse(_ apiService: AppAmbitApiService, endpoint: Endpoint) -> HTTPTransportResponse {
+        let expectation = expectation(description: "raw response")
+        let box = RawResponseBox()
+        apiService.executeRawRequest(endpoint, timeout: 2) { response in
+            box.set(response)
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 2)
+        return box.value!
+    }
+
     private func waitForUntyped(
         _ start: (@escaping @Sendable (CloudCodeResponse?, Error?) -> Void) -> Void
     ) -> (CloudCodeResponse?, Error?) {
@@ -384,19 +460,19 @@ final class CloudCodeTests: XCTestCase {
     }
 }
 
-private final class TestCloudCodeTransport: CloudCodeTransport, @unchecked Sendable {
+private final class TestCloudCodeTransport: HTTPTransport, @unchecked Sendable {
     private let lock = NSLock()
-    private var pendingCompletion: (@Sendable (CloudCodeTransportResponse) -> Void)?
+    private var pendingCompletion: (@Sendable (HTTPTransportResponse) -> Void)?
 
     var response: CloudCodeTransportResponse?
     private(set) var requestCount = 0
     private(set) var lastTimeout: TimeInterval?
-    private(set) var lastEndpoint: CloudCodeEndpoint?
+    private(set) var lastEndpoint: Endpoint?
 
-    func executeCloudCodeRequest(
-        _ endpoint: CloudCodeEndpoint,
+    func executeRawRequest(
+        _ endpoint: Endpoint,
         timeout: TimeInterval,
-        completion: @escaping @Sendable (CloudCodeTransportResponse) -> Void
+        completion: @escaping @Sendable (HTTPTransportResponse) -> Void
     ) {
         lock.lock()
         requestCount += 1
@@ -413,7 +489,7 @@ private final class TestCloudCodeTransport: CloudCodeTransport, @unchecked Senda
         }
     }
 
-    func deliver(_ response: CloudCodeTransportResponse) {
+    func deliver(_ response: HTTPTransportResponse) {
         lock.lock()
         let completion = pendingCompletion
         pendingCompletion = nil
@@ -431,6 +507,34 @@ private final class ResultBox<Value, Failure: Error>: @unchecked Sendable {
         lock.lock()
         self.value = value
         self.error = error
+        lock.unlock()
+    }
+}
+
+private final class RequestCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedRequests: [URLRequest] = []
+
+    var requests: [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedRequests
+    }
+
+    func append(_ request: URLRequest) {
+        lock.lock()
+        storedRequests.append(request)
+        lock.unlock()
+    }
+}
+
+private final class RawResponseBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var value: HTTPTransportResponse?
+
+    func set(_ value: HTTPTransportResponse) {
+        lock.lock()
+        self.value = value
         lock.unlock()
     }
 }

--- a/AppAmbitSdk/Tests/CloudCodeTests.swift
+++ b/AppAmbitSdk/Tests/CloudCodeTests.swift
@@ -79,6 +79,27 @@ final class CloudCodeTests: XCTestCase {
         XCTAssertEqual(transport.requestCount, 0)
     }
 
+    func testFunctionSlugsRejectSpacesAndControlCharactersBeforeTransport() {
+        for function in ["hello world", "hello\u{0000}world"] {
+            let transport = TestCloudCodeTransport()
+            let service = CloudCodeService(transport: transport)
+
+            let (_, error) = waitForUntyped { completion in
+                service.call(
+                    function: function,
+                    method: .get,
+                    query: nil,
+                    body: nil,
+                    headers: nil,
+                    completion: completion
+                )
+            }
+
+            XCTAssertEqual(error as? CloudCodeError, .invalidFunction(function))
+            XCTAssertEqual(transport.requestCount, 0)
+        }
+    }
+
     func testInvalidBodyAndReservedHeadersAreRejectedBeforeTransport() {
         let transport = TestCloudCodeTransport()
         let service = CloudCodeService(transport: transport)
@@ -485,6 +506,69 @@ final class CloudCodeTests: XCTestCase {
         }
     }
 
+    func testHTTPErrorParsesOnlyObjectsAndArraysAndPreservesRawScalars() {
+        let structuredBodies: [(String, JSONValue)] = [
+            ("{\"error\":\"failed\"}", .object(["error": .string("failed")])),
+            ("[\"failed\",1]", .array([.string("failed"), .int(1)]))
+        ]
+
+        for (rawBody, expectedBody) in structuredBodies {
+            let transport = TestCloudCodeTransport()
+            transport.response = CloudCodeTransportResponse(
+                statusCode: 500,
+                data: Data(rawBody.utf8),
+                headers: [:],
+                error: nil
+            )
+            let service = CloudCodeService(transport: transport)
+
+            let (_, error) = waitForUntyped { completion in
+                service.call(
+                    function: "structured-error",
+                    method: .get,
+                    query: nil,
+                    body: nil,
+                    headers: nil,
+                    completion: completion
+                )
+            }
+
+            guard case .http(_, let body, let rawBody, _) = error as? CloudCodeError else {
+                return XCTFail("Expected structured HTTP error, got \(String(describing: error))")
+            }
+            XCTAssertEqual(body, expectedBody)
+            XCTAssertNil(rawBody)
+        }
+
+        for rawBody in ["<html><body>gateway failure</body></html>", "\"failed\"", "42", "true", "null"] {
+            let transport = TestCloudCodeTransport()
+            transport.response = CloudCodeTransportResponse(
+                statusCode: 500,
+                data: Data(rawBody.utf8),
+                headers: [:],
+                error: nil
+            )
+            let service = CloudCodeService(transport: transport)
+
+            let (_, error) = waitForUntyped { completion in
+                service.call(
+                    function: "raw-error",
+                    method: .get,
+                    query: nil,
+                    body: nil,
+                    headers: nil,
+                    completion: completion
+                )
+            }
+
+            guard case .http(_, let body, let preservedBody, _) = error as? CloudCodeError else {
+                return XCTFail("Expected raw HTTP error, got \(String(describing: error))")
+            }
+            XCTAssertNil(body)
+            XCTAssertEqual(preservedBody, rawBody)
+        }
+    }
+
     func testNoCallbackAfterCancellation() {
         let transport = TestCloudCodeTransport()
         let service = CloudCodeService(transport: transport)
@@ -501,13 +585,13 @@ final class CloudCodeTests: XCTestCase {
             callbackExpectation.fulfill()
         }
 
-        token.cancel()
         transport.deliver(CloudCodeTransportResponse(
             statusCode: 200,
             data: Data("{\"ok\":true}".utf8),
             headers: [:],
             error: nil
         ))
+        token.cancel()
         wait(for: [callbackExpectation], timeout: 0.2)
     }
 
@@ -663,6 +747,11 @@ final class CloudCodeTests: XCTestCase {
         XCTAssertEqual(response?.statusCode, 200)
         XCTAssertEqual(response?.data as? [String: Bool], ["ok": true])
         XCTAssertEqual(cloudRequests.count, 2)
+        XCTAssertEqual(
+            cloudRequests[0].timeoutInterval,
+            AppConstants.cloudCodeTimeout,
+            accuracy: 0.1
+        )
         XCTAssertEqual(cloudRequests[0].value(forHTTPHeaderField: "Authorization"), "Bearer stale-token")
         XCTAssertEqual(cloudRequests[1].value(forHTTPHeaderField: "Authorization"), "Bearer fresh-token")
         XCTAssertEqual(requestCapture.requests.filter { $0.url?.path.hasSuffix("/consumer/token") == true }.count, 1)
@@ -728,6 +817,72 @@ final class CloudCodeTests: XCTestCase {
         XCTAssertEqual(requestId, "still-unauthorized")
         XCTAssertEqual(cloudRequests.count, 2)
         XCTAssertEqual(requestCapture.requests.filter { $0.url?.path.hasSuffix("/consumer/token") == true }.count, 1)
+    }
+
+    func testCloudCodeGatewayDoesNotRetryMutatingMethodsAfter401() throws {
+        let requestCapture = RequestCapture()
+        TestURLProtocol.requestHandler = { request in
+            requestCapture.append(request)
+            let response: HTTPURLResponse
+            let body: Data
+            if request.url?.path.hasSuffix("/consumer/token") == true {
+                response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                )!
+                body = Data("{\"id\":123,\"token\":\"fresh-token\"}".utf8)
+            } else {
+                response = HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 401,
+                    httpVersion: nil,
+                    headerFields: ["X-Request-Id": "mutation-unauthorized"]
+                )!
+                body = Data("{\"error\":\"expired\"}".utf8)
+            }
+            return (response, body)
+        }
+        defer { TestURLProtocol.reset() }
+
+        let storage = InMemoryStorage()
+        try storage.putAppId("test-app")
+        try storage.putConsumerId("test-consumer")
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [TestURLProtocol.self]
+        let apiService = AppAmbitApiService(
+            storageService: storage,
+            urlSession: URLSession(configuration: configuration),
+            isConnected: { true }
+        )
+        apiService.setToken("stale-token")
+        let service = CloudCodeService(transport: apiService)
+
+        for (function, method) in [("post-mutation", CloudCodeHttpMethod.post),
+                                    ("put-mutation", .put),
+                                    ("delete-mutation", .delete)] {
+            let (response, error) = waitForUntyped { completion in
+                service.call(
+                    function: function,
+                    method: method,
+                    query: nil,
+                    body: ["value": true],
+                    headers: nil,
+                    completion: completion
+                )
+            }
+
+            guard case .http(let statusCode, _, _, let requestId) = error as? CloudCodeError else {
+                return XCTFail("Expected HTTP 401 for \(method), got \(String(describing: error))")
+            }
+            XCTAssertNil(response)
+            XCTAssertEqual(statusCode, 401)
+            XCTAssertEqual(requestId, "mutation-unauthorized")
+        }
+
+        XCTAssertEqual(requestCapture.requests.filter { $0.url?.path.contains("/fn/") == true }.count, 3)
+        XCTAssertEqual(requestCapture.requests.filter { $0.url?.path.hasSuffix("/consumer/token") == true }.count, 0)
     }
 
     func testConcurrentCloudCode401RequestsShareOneTokenRenewal() throws {

--- a/AppAmbitSdk/Tests/TestDoubles.swift
+++ b/AppAmbitSdk/Tests/TestDoubles.swift
@@ -29,6 +29,14 @@ final class StubApiService: ApiService {
         completion(ApiResult(data: nil, errorType: .none))
     }
 
+    func executeRawRequest(
+        _ endpoint: Endpoint,
+        timeout: TimeInterval,
+        completion: @escaping @Sendable (HTTPTransportResponse) -> Void
+    ) {
+        completion(HTTPTransportResponse(statusCode: nil, data: nil, headers: [:], error: nil))
+    }
+
     func getNewToken(completion: @escaping @Sendable (ApiErrorType) -> Void) {
         completion(.none)
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Version 1.2.0
+
+- Added Cloud Code HTTP invocation for Swift and Objective-C.
+- Added typed and untyped JSON responses, request IDs, cancellation, reserved-header validation, and a 60-second Cloud Code timeout.
+- Added Cloud Code sample tabs and backend demonstration functions for Database, CMS, Push, event triggers, manual triggers, errors, and timeout behavior.
+
+___
+
 ## Version 1.1.2
 
 ### AppAmbit Push Notifications

--- a/README.md
+++ b/README.md
@@ -316,6 +316,8 @@ CloudCode.call("hello", body: ["name": "Ada"]
 
 See the complete [Cloud Code mobile guide](https://docs.appambit.com/sdk-guides/cloud-code/) for function setup, HTTP triggers, typed and dynamic responses, errors, request IDs, cancellation, timeouts, and backend examples.
 
+For the dynamic response API, a successful empty body, a `204 No Content` response, and an explicit JSON `null` are represented as `NSNull()` in `CloudCodeResponse.data`. Android exposes the equivalent value as `null`. Typed responses preserve their status and request metadata; an empty successful body produces `nil` typed data.
+
 ## Release Distribution
 
 * Push the artifact to your AppAmbit dashboard for distribution via email and direct installation.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Lightweight SDK for analytics, events, logging, crashes, and offline support. Si
 * [Install](#install)
 * [Quickstart](#quickstart)
 * [Usage](#usage)
+* [Cloud Code](#cloud-code)
 * [Release Distribution](#release-distribution)
 * [Privacy and Data](#privacy-and-data)
 * [Troubleshooting](#troubleshooting)
@@ -36,6 +37,7 @@ Lightweight SDK for analytics, events, logging, crashes, and offline support. Si
 * Crash capture with stack traces and threads
 * Offline support with batching, retry, and queue
 * Database – query, insert, update and delete remote data with a fluent builder
+* Cloud Code – invoke authenticated HTTP functions with JSON, typed results, cancellation, and request correlation
 * Create mutliple app profiles for staging and production
 * Small footprint, modern Swift API with full Objective-C support
 
@@ -53,7 +55,7 @@ Lightweight SDK for analytics, events, logging, crashes, and offline support. Si
 
 ### Swift Package Manager
 
-> Requires **v1.1.2 or newer**. Earlier tags do not include the corrected SPM target separation.
+> Requires **v1.2.0 or newer**. Earlier tags do not include Cloud Code support.
 
 #### In Xcode
 
@@ -64,7 +66,7 @@ Lightweight SDK for analytics, events, logging, crashes, and offline support. Si
    https://github.com/AppAmbit/appambit-sdk-ios
    ```
 
-3. Set **Dependency Rule** to **Up to Next Major Version** starting at `v1.1.2`.
+3. Set **Dependency Rule** to **Up to Next Major Version** starting at `v1.2.0`.
 4. Click **Add Package**, then attach each product to the target that needs it:
 
 | Product | Add to target | Import |
@@ -104,7 +106,7 @@ troubleshooting.
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/AppAmbit/appambit-sdk-ios", from: "1.1.2")
+    .package(url: "https://github.com/AppAmbit/appambit-sdk-ios", from: "1.2.0")
 ],
 targets: [
     .target(
@@ -123,7 +125,7 @@ Add this to your Podfile:
 ```ruby
 pod 'AppAmbitSdk'
 # or specify version
-pod 'AppAmbitSdk', '~> 1.1.2'
+pod 'AppAmbitSdk', '~> 1.2.0'
 ```
 
 Then run:
@@ -279,6 +281,40 @@ AppAmbit.start(appKey: "<YOUR-APPKEY>")
   ```
 
 ---
+
+## Cloud Code
+
+Cloud Code lets your app invoke authenticated HTTP functions hosted by AppAmbit. Initialize the SDK as usual; Cloud Code uses the same consumer and Bearer token as the rest of the SDK.
+
+```swift
+AppAmbit.start(appKey: "<YOUR-APPKEY>")
+```
+
+After configuring an active Cloud Function with an enabled HTTP trigger and slug in the Dashboard, call it from Swift or Objective-C:
+
+```swift
+CloudCode.call("hello", body: ["name": "Ada"]
+) { response, error in
+    print(response?.data ?? error ?? "Unknown result")
+}
+```
+
+```objective-c
+[CloudCode call:@"hello"
+           method:CloudCodeHttpMethodPost
+            query:nil
+             body:@{ @"name": @"Ada" }
+          headers:nil
+      completion:^(CloudCodeResponse *response, NSError *error) {
+    if (error != nil) {
+        NSLog(@"Cloud Code error: %@", error);
+        return;
+    }
+    NSLog(@"%@", response.data);
+}];
+```
+
+See the complete [Cloud Code mobile guide](https://docs.appambit.com/sdk-guides/cloud-code/) for function setup, HTTP triggers, typed and dynamic responses, errors, request IDs, cancellation, timeouts, and backend examples.
 
 ## Release Distribution
 

--- a/Samples/AppAmbit.App.ObjC/CloudCodeViewController.h
+++ b/Samples/AppAmbit.App.ObjC/CloudCodeViewController.h
@@ -1,0 +1,4 @@
+#import <UIKit/UIKit.h>
+
+@interface CloudCodeViewController : UIViewController
+@end

--- a/Samples/AppAmbit.App.ObjC/CloudCodeViewController.m
+++ b/Samples/AppAmbit.App.ObjC/CloudCodeViewController.m
@@ -17,6 +17,9 @@
 @property (nonatomic, strong) UIStackView *resultContainer;
 @property (nonatomic, strong) UILabel *databaseStatusLabel;
 @property (nonatomic, strong) UILabel *cmsStatusLabel;
+@property (nonatomic, strong) UIButton *databaseSetupButton;
+@property (nonatomic, assign) BOOL databaseAvailable;
+@property (nonatomic, assign) BOOL databaseTablesReady;
 @property (nonatomic, copy) NSString *fullResultText;
 @property (nonatomic, assign) BOOL resultExpanded;
 @property (nonatomic, assign) BOOL verifyingBackend;
@@ -238,23 +241,66 @@
     UILabel *status = [self label:@"Not available" style:UIFontTextStyleCaption1];
     status.font = [UIFont systemFontOfSize:status.font.pointSize weight:UIFontWeightSemibold];
     status.textColor = UIColor.secondaryLabelColor;
-    [statusRow addArrangedSubview:status];
-    [statusRow addArrangedSubview:[UIView new]];
-    if (function.length > 0) {
-        UIButton *button = [self actionButtonWithTitle:function action:action];
-        [statusRow addArrangedSubview:button];
-    }
-    [content addArrangedSubview:statusRow];
+     [statusRow addArrangedSubview:status];
+     [statusRow addArrangedSubview:[UIView new]];
+     [content addArrangedSubview:statusRow];
 
-    [NSLayoutConstraint activateConstraints:@[
+     if (function.length > 0) {
+         UIView *setupCard = [UIView new];
+         setupCard.backgroundColor = [UIColor.secondarySystemBackgroundColor colorWithAlphaComponent:0.9];
+         setupCard.layer.cornerRadius = 10;
+
+         UIStackView *setupContent = [[UIStackView alloc] init];
+         setupContent.axis = UILayoutConstraintAxisVertical;
+         setupContent.spacing = 6;
+         setupContent.translatesAutoresizingMaskIntoConstraints = NO;
+         [setupCard addSubview:setupContent];
+
+         UIStackView *setupRow = [[UIStackView alloc] init];
+         setupRow.axis = UILayoutConstraintAxisHorizontal;
+         setupRow.alignment = UIStackViewAlignmentCenter;
+         setupRow.spacing = 8;
+
+         UIStackView *info = [[UIStackView alloc] init];
+         info.axis = UILayoutConstraintAxisVertical;
+         info.spacing = 2;
+         UILabel *functionLabel = [self label:function style:UIFontTextStyleSubheadline];
+         functionLabel.font = [UIFont systemFontOfSize:functionLabel.font.pointSize weight:UIFontWeightSemibold];
+         UILabel *detailLabel = [self label:@"Create the tables used by the Database examples without destroying data." style:UIFontTextStyleCaption1];
+         detailLabel.textColor = UIColor.secondaryLabelColor;
+         detailLabel.numberOfLines = 0;
+         UILabel *prerequisiteLabel = [self label:@"Existing linked Database" style:UIFontTextStyleCaption2];
+         prerequisiteLabel.textColor = UIColor.secondaryLabelColor;
+         prerequisiteLabel.numberOfLines = 0;
+         [info addArrangedSubview:functionLabel];
+         [info addArrangedSubview:detailLabel];
+         [info addArrangedSubview:prerequisiteLabel];
+
+         self.databaseSetupButton = [self actionButtonWithTitle:@"Run" action:action];
+         self.databaseSetupButton.accessibilityLabel = function;
+         self.databaseSetupButton.enabled = NO;
+         [setupRow addArrangedSubview:info];
+         [setupRow addArrangedSubview:self.databaseSetupButton];
+         [setupContent addArrangedSubview:setupRow];
+         [content addArrangedSubview:setupCard];
+
+         [NSLayoutConstraint activateConstraints:@[
+             [setupContent.topAnchor constraintEqualToAnchor:setupCard.topAnchor constant:10],
+             [setupContent.leadingAnchor constraintEqualToAnchor:setupCard.leadingAnchor constant:12],
+             [setupContent.trailingAnchor constraintEqualToAnchor:setupCard.trailingAnchor constant:-12],
+             [setupContent.bottomAnchor constraintEqualToAnchor:setupCard.bottomAnchor constant:-10]
+         ]];
+         self.functionCards[function] = group;
+     }
+
+     [NSLayoutConstraint activateConstraints:@[
         [content.topAnchor constraintEqualToAnchor:group.topAnchor constant:12],
         [content.leadingAnchor constraintEqualToAnchor:group.leadingAnchor constant:12],
         [content.trailingAnchor constraintEqualToAnchor:group.trailingAnchor constant:-12],
         [content.bottomAnchor constraintEqualToAnchor:group.bottomAnchor constant:-12]
-    ]];
-    [self.stack addArrangedSubview:group];
-    if (function.length > 0) self.functionCards[function] = group;
-    return status;
+     ]];
+     [self.stack addArrangedSubview:group];
+     return status;
 }
 
 - (UIButton *)actionButtonWithTitle:(NSString *)title action:(SEL)action {
@@ -344,6 +390,7 @@
 - (void)runFunction:(NSString *)function method:(CloudCodeHttpMethod)method query:(NSDictionary *)query body:(NSDictionary *)body {
     if (self.spinner.isAnimating) return;
     [self.spinner startAnimating];
+    [self updateDatabaseSetupButtonState];
     [self prepareResultForFunction:function];
     [self setResultText:[NSString stringWithFormat:@"Calling %@...", function]];
     NSDate *started = [NSDate date];
@@ -352,13 +399,17 @@
         NSTimeInterval elapsed = -[started timeIntervalSinceNow];
         dispatch_async(dispatch_get_main_queue(), ^{
             __strong typeof(weakSelf) self = weakSelf;
-            if (!self) return;
-            [self.spinner stopAnimating];
-            if (response) {
-                [self setResultText:[NSString stringWithFormat:@"HTTP %ld\nDuration: %.2f s\nrequestId: %@\nBody: %@", (long)response.statusCode, elapsed, response.requestId ?: @"none", [self jsonText:response.data]]];
-            } else {
-                [self setResultText:[NSString stringWithFormat:@"Duration: %.2f s\nError: %@", elapsed, error.localizedDescription ?: @"Unknown error"]];
-            }
+             if (!self) return;
+             [self.spinner stopAnimating];
+             [self updateDatabaseSetupButtonState];
+             if (response) {
+                 [self setResultText:[NSString stringWithFormat:@"HTTP %ld\nDuration: %.2f s\nrequestId: %@\nBody: %@", (long)response.statusCode, elapsed, response.requestId ?: @"none", [self jsonText:response.data]]];
+             } else {
+                 [self setResultText:[NSString stringWithFormat:@"Duration: %.2f s\nError: %@", elapsed, error.localizedDescription ?: @"Unknown error"]];
+             }
+             if ([function isEqualToString:@"cloud-demo-setup-database-ios"]) {
+                 [self verifyBackend];
+             }
         });
     }];
 }
@@ -380,9 +431,12 @@
     }
 }
 
-- (void)verifyBackend {
+ - (void)verifyBackend {
     if (self.verifyingBackend) return;
-    self.verifyingBackend = YES;
+     self.verifyingBackend = YES;
+     self.databaseAvailable = NO;
+     self.databaseTablesReady = NO;
+     [self updateDatabaseSetupButtonState];
     self.databaseStatusLabel.text = @"Checking...";
     self.cmsStatusLabel.text = @"Checking...";
     self.databaseStatusLabel.textColor = UIColor.secondaryLabelColor;
@@ -398,24 +452,39 @@
         dispatch_async(dispatch_get_main_queue(), ^{
             __strong typeof(weakSelf) self = weakSelf;
             if (!self) return;
-            self.verifyingBackend = NO;
-            if (!response || response.statusCode != 200 || ![response.data isKindOfClass:NSDictionary.class]) {
-                self.databaseStatusLabel.text = @"Not available";
-                self.cmsStatusLabel.text = @"Not available";
-                self.databaseStatusLabel.textColor = UIColor.secondaryLabelColor;
-                self.cmsStatusLabel.textColor = UIColor.secondaryLabelColor;
-                return;
-            }
+             self.verifyingBackend = NO;
+             if (!response || response.statusCode != 200 || ![response.data isKindOfClass:NSDictionary.class]) {
+                 self.databaseAvailable = NO;
+                 self.databaseTablesReady = NO;
+                 self.databaseStatusLabel.text = @"Not available";
+                 self.cmsStatusLabel.text = @"Not available";
+                 self.databaseStatusLabel.textColor = UIColor.secondaryLabelColor;
+                 self.cmsStatusLabel.textColor = UIColor.secondaryLabelColor;
+                 [self updateDatabaseSetupButtonState];
+                 return;
+             }
 
-            NSDictionary *payload = (NSDictionary *)response.data;
-            BOOL databaseAvailable = payload[@"task_count"] != nil;
-            BOOL cmsAvailable = payload[@"posts"] != nil;
-            self.databaseStatusLabel.text = databaseAvailable ? @"Available" : @"Not available";
-            self.cmsStatusLabel.text = cmsAvailable ? @"Available" : @"Not available";
-            self.databaseStatusLabel.textColor = databaseAvailable ? UIColor.systemGreenColor : UIColor.secondaryLabelColor;
-            self.cmsStatusLabel.textColor = cmsAvailable ? UIColor.systemGreenColor : UIColor.secondaryLabelColor;
-        });
-    }];
+             NSDictionary *payload = (NSDictionary *)response.data;
+             self.databaseAvailable = [payload[@"database_available"] boolValue];
+             self.databaseTablesReady = [payload[@"database_tables_ready"] boolValue];
+             BOOL cmsAvailable = payload[@"posts"] != nil;
+             if (!self.databaseAvailable) {
+                 self.databaseStatusLabel.text = @"Not available";
+             } else if (self.databaseTablesReady) {
+                 self.databaseStatusLabel.text = @"Tables ready";
+             } else {
+                 self.databaseStatusLabel.text = @"Available";
+             }
+             self.cmsStatusLabel.text = cmsAvailable ? @"Available" : @"Not available";
+             self.databaseStatusLabel.textColor = self.databaseAvailable ? UIColor.systemGreenColor : UIColor.secondaryLabelColor;
+             self.cmsStatusLabel.textColor = cmsAvailable ? UIColor.systemGreenColor : UIColor.secondaryLabelColor;
+             [self updateDatabaseSetupButtonState];
+         });
+     }];
+}
+
+- (void)updateDatabaseSetupButtonState {
+    self.databaseSetupButton.enabled = self.databaseAvailable && !self.databaseTablesReady && !self.verifyingBackend && !self.spinner.isAnimating;
 }
 
 - (void)toggleResult {
@@ -451,6 +520,7 @@
 
 - (void)createTask { [self runFunction:@"cloud-demo-create-task-ios" method:CloudCodeHttpMethodPost query:nil body:@{ @"title": self.titleField.text ?: @"" }]; }
 - (void)createTables {
+     if (!self.databaseAvailable || self.databaseTablesReady) return;
      [self confirmAndRun:@"cloud-demo-setup-database-ios" handler:^{
          [self runFunction:@"cloud-demo-setup-database-ios" method:CloudCodeHttpMethodPost query:nil body:nil];
     }];

--- a/Samples/AppAmbit.App.ObjC/CloudCodeViewController.m
+++ b/Samples/AppAmbit.App.ObjC/CloudCodeViewController.m
@@ -1,0 +1,548 @@
+#import "CloudCodeViewController.h"
+#import <UserNotifications/UserNotifications.h>
+
+@import AppAmbit;
+@import AppAmbitPushNotifications;
+
+@interface CloudCodeViewController ()
+@property (nonatomic, strong) UIStackView *stack;
+@property (nonatomic, strong) UITextField *titleField;
+@property (nonatomic, strong) UITextField *taskIdField;
+@property (nonatomic, strong) UITextField *uuidField;
+@property (nonatomic, strong) UITextField *publishTitleField;
+@property (nonatomic, strong) UITextField *publishBodyField;
+@property (nonatomic, strong) UILabel *resultLabel;
+@property (nonatomic, strong) UILabel *resultTitleLabel;
+@property (nonatomic, strong) UIButton *resultToggleButton;
+@property (nonatomic, strong) UIStackView *resultContainer;
+@property (nonatomic, strong) UILabel *databaseStatusLabel;
+@property (nonatomic, strong) UILabel *cmsStatusLabel;
+@property (nonatomic, copy) NSString *fullResultText;
+@property (nonatomic, assign) BOOL resultExpanded;
+@property (nonatomic, assign) BOOL verifyingBackend;
+@property (nonatomic, strong) UIActivityIndicatorView *spinner;
+@property (nonatomic, strong) NSMutableDictionary<NSString *, UIView *> *functionCards;
+@end
+
+@implementation CloudCodeViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.title = @"Cloud Code";
+    self.view.backgroundColor = UIColor.systemBackgroundColor;
+    [self buildUI];
+    [self verifyBackend];
+}
+
+- (void)buildUI {
+    UIScrollView *scroll = [UIScrollView new];
+    scroll.translatesAutoresizingMaskIntoConstraints = NO;
+    [self.view addSubview:scroll];
+
+    self.stack = [[UIStackView alloc] init];
+    self.stack.axis = UILayoutConstraintAxisVertical;
+    self.stack.spacing = 8;
+    self.stack.alignment = UIStackViewAlignmentFill;
+    self.stack.translatesAutoresizingMaskIntoConstraints = NO;
+    [scroll addSubview:self.stack];
+    self.functionCards = [NSMutableDictionary dictionary];
+
+    self.databaseStatusLabel = [self addSetupGroup:@"Database"
+                                        requirement:@"Create Database first"
+                                               tint:UIColor.systemBlueColor
+                                          function:@"cloud-demo-setup-database"
+                                            action:@selector(createTables)];
+
+    self.cmsStatusLabel = [self addSetupGroup:@"CMS"
+                                    requirement:@"Create Content Type first"
+                                           tint:UIColor.systemPurpleColor
+                                      function:nil
+                                        action:NULL];
+
+    self.titleField = [self field:@"Task title" value:@"Buy coffee"];
+    self.taskIdField = [self field:@"Task id" value:@""];
+    self.taskIdField.keyboardType = UIKeyboardTypeNumberPad;
+    self.uuidField = [self field:@"CMS post UUID (optional)" value:@""];
+    self.publishTitleField = [self field:@"Sample title" value:@"Cloud Code sample post"];
+    self.publishBodyField = [self field:@"Sample body" value:@"Published through an HTTP Cloud Function."];
+
+    [self addSectionHeader:@"Database"];
+    [self.stack addArrangedSubview:self.titleField];
+    [self.stack addArrangedSubview:self.taskIdField];
+    [self addFunctionCard:@"cloud-demo-create-task"
+                   detail:@"Insert a task for the signed-in consumer."
+             prerequisite:@"Requires cloud_demo_tasks"
+                    action:@selector(createTask)];
+    [self addFunctionCard:@"cloud-demo-list-tasks"
+                   detail:@"Read the current consumer's tasks."
+             prerequisite:@"Requires cloud_demo_tasks"
+                    action:@selector(listTasks)];
+    [self addFunctionCard:@"cloud-demo-complete-task"
+                   detail:@"Update one task with consumer ownership."
+             prerequisite:@"Requires a task id"
+                    action:@selector(completeTask)];
+    [self addFunctionCard:@"cloud-demo-delete-task"
+                   detail:@"Delete one task owned by the consumer."
+             prerequisite:@"Requires a task id and confirmation"
+                    action:@selector(deleteTask)];
+    [self addFunctionCard:@"cloud-demo-create-order"
+                   detail:@"Create an order without duplicate idempotency keys."
+             prerequisite:@"Requires cloud_demo_orders"
+                    action:@selector(createOrder)];
+    [self addFunctionCard:@"cloud-demo-dashboard-summary"
+                   detail:@"Combine Database and CMS in one response."
+             prerequisite:@"Requires Database and CMS setup"
+                    action:@selector(summary)];
+
+    [self addSectionHeader:@"CMS"];
+    [self.stack addArrangedSubview:self.uuidField];
+    [self.stack addArrangedSubview:self.publishTitleField];
+    [self.stack addArrangedSubview:self.publishBodyField];
+    [self addFunctionCard:@"cloud-demo-publish-post"
+                   detail:@"Create a published CMS entry."
+             prerequisite:@"Requires confirmation and cloud_code_demo_posts"
+                    action:@selector(createSampleContent)];
+    [self addFunctionCard:@"cloud-demo-read-posts"
+                   detail:@"List published entries using only CMS data."
+             prerequisite:@"Requires cloud_code_demo_posts"
+                    action:@selector(readPosts)];
+
+    [self addSectionHeader:@"Push"];
+    [self addFunctionCard:@"cloud-demo-send-push"
+                   detail:@"Send a notification to all consumers."
+             prerequisite:@"Requires permission and APNs/FCM"
+                    action:@selector(sendPush)];
+
+    [self addSectionHeader:@"HTTP"];
+    [self addFunctionCard:@"cloud-demo-http-inspector"
+                   detail:@"Inspect method, query, body and consumer context."
+             prerequisite:@"Requires an HTTP trigger"
+                    action:@selector(inspectContext)];
+    [self addFunctionCard:@"cloud-demo-json-values"
+                   detail:@"Return common JSON value types."
+             prerequisite:@"Requires an HTTP trigger"
+                    action:@selector(jsonValues)];
+    [self addFunctionCard:@"cloud-demo-null-contract"
+                   detail:@"Compare raw null and an explicit value."
+             prerequisite:@"Requires an HTTP trigger"
+                    action:@selector(nullContract)];
+    [self addFunctionCard:@"cloud-demo-response-shapes"
+                   detail:@"Demonstrate statuses, body and headers."
+             prerequisite:@"Requires an HTTP trigger"
+                    action:@selector(responseShapes)];
+    [self addFunctionCard:@"cloud-demo-error-response"
+                   detail:@"Return a safe client error response."
+             prerequisite:@"Requires an HTTP trigger"
+                    action:@selector(controlledError)];
+    [self addFunctionCard:@"cloud-demo-timeout-10s"
+                   detail:@"Observe the configured function timeout."
+             prerequisite:@"Requires a 10 second function timeout"
+                    action:@selector(timeoutDemo)];
+    [self addFunctionCard:@"cloud-demo-runtime-context"
+                   detail:@"Use environment values, secrets and logs safely."
+             prerequisite:@"Requires DEMO_REGION and DEMO_SECRET"
+                    action:@selector(runtimeContext)];
+
+    self.spinner = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
+    [self.stack addArrangedSubview:self.spinner];
+    self.resultContainer = [[UIStackView alloc] init];
+    self.resultContainer.axis = UILayoutConstraintAxisVertical;
+    self.resultContainer.spacing = 8;
+    UIStackView *resultHeader = [[UIStackView alloc] init];
+    resultHeader.axis = UILayoutConstraintAxisHorizontal;
+    resultHeader.alignment = UIStackViewAlignmentCenter;
+    resultHeader.spacing = 8;
+    self.resultTitleLabel = [self label:@"Latest result" style:UIFontTextStyleSubheadline];
+    self.resultTitleLabel.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
+    self.resultToggleButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [self.resultToggleButton setTitle:@"Collapse" forState:UIControlStateNormal];
+    [self.resultToggleButton addTarget:self action:@selector(toggleResult) forControlEvents:UIControlEventTouchUpInside];
+    [resultHeader addArrangedSubview:self.resultTitleLabel];
+    [resultHeader addArrangedSubview:[UIView new]];
+    [resultHeader addArrangedSubview:self.resultToggleButton];
+    [self.resultContainer addArrangedSubview:resultHeader];
+
+    self.fullResultText = @"Run a function to see its response here.";
+    self.resultLabel = [self label:self.fullResultText style:UIFontTextStyleCaption1];
+    self.resultExpanded = YES;
+    self.resultLabel.numberOfLines = 0;
+    self.resultLabel.font = [UIFont monospacedSystemFontOfSize:12 weight:UIFontWeightRegular];
+    [self.resultContainer addArrangedSubview:self.resultLabel];
+    self.resultContainer.hidden = YES;
+    [self.stack addArrangedSubview:self.resultContainer];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [scroll.topAnchor constraintEqualToAnchor:self.view.safeAreaLayoutGuide.topAnchor],
+        [scroll.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
+        [scroll.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
+        [scroll.bottomAnchor constraintEqualToAnchor:self.view.bottomAnchor],
+        [self.stack.topAnchor constraintEqualToAnchor:scroll.contentLayoutGuide.topAnchor constant:16],
+        [self.stack.leadingAnchor constraintEqualToAnchor:scroll.contentLayoutGuide.leadingAnchor constant:16],
+        [self.stack.trailingAnchor constraintEqualToAnchor:scroll.contentLayoutGuide.trailingAnchor constant:-16],
+        [self.stack.bottomAnchor constraintEqualToAnchor:scroll.contentLayoutGuide.bottomAnchor constant:-16],
+        [self.stack.widthAnchor constraintEqualToAnchor:scroll.frameLayoutGuide.widthAnchor constant:-32]
+    ]];
+}
+
+- (UILabel *)label:(NSString *)text style:(UIFontTextStyle)style {
+    UILabel *label = [UILabel new];
+    label.text = text;
+    label.font = [UIFont preferredFontForTextStyle:style];
+    return label;
+}
+
+- (void)addSectionHeader:(NSString *)title {
+    UILabel *header = [self label:title style:UIFontTextStyleHeadline];
+    header.textColor = UIColor.labelColor;
+    header.font = [UIFont preferredFontForTextStyle:UIFontTextStyleHeadline];
+    [self.stack addArrangedSubview:header];
+}
+
+- (UITextField *)field:(NSString *)placeholder value:(NSString *)value {
+    UITextField *field = [UITextField new];
+    field.placeholder = placeholder;
+    field.text = value;
+    field.borderStyle = UITextBorderStyleRoundedRect;
+    return field;
+}
+
+- (UILabel *)addSetupGroup:(NSString *)title
+               requirement:(NSString *)requirement
+                      tint:(UIColor *)tint
+                 function:(NSString *)function
+                   action:(SEL)action {
+    UIView *group = [UIView new];
+    group.backgroundColor = UIColor.secondarySystemBackgroundColor;
+    group.layer.cornerRadius = 10;
+    group.layer.borderWidth = 1;
+    group.layer.borderColor = UIColor.separatorColor.CGColor;
+
+    UIStackView *content = [[UIStackView alloc] init];
+    content.axis = UILayoutConstraintAxisVertical;
+    content.spacing = 8;
+    content.translatesAutoresizingMaskIntoConstraints = NO;
+    [group addSubview:content];
+
+    UILabel *titleLabel = [self label:title style:UIFontTextStyleHeadline];
+    [content addArrangedSubview:titleLabel];
+
+    UILabel *requirementLabel = [self label:requirement style:UIFontTextStyleCaption2];
+    requirementLabel.font = [UIFont systemFontOfSize:requirementLabel.font.pointSize weight:UIFontWeightSemibold];
+    requirementLabel.textColor = tint;
+    [content addArrangedSubview:requirementLabel];
+
+    UIStackView *statusRow = [[UIStackView alloc] init];
+    statusRow.axis = UILayoutConstraintAxisHorizontal;
+    statusRow.alignment = UIStackViewAlignmentCenter;
+    statusRow.spacing = 8;
+    UILabel *status = [self label:@"Not available" style:UIFontTextStyleCaption1];
+    status.font = [UIFont systemFontOfSize:status.font.pointSize weight:UIFontWeightSemibold];
+    status.textColor = UIColor.secondaryLabelColor;
+    [statusRow addArrangedSubview:status];
+    [statusRow addArrangedSubview:[UIView new]];
+    if (function.length > 0) {
+        UIButton *button = [self actionButtonWithTitle:function action:action];
+        [statusRow addArrangedSubview:button];
+    }
+    [content addArrangedSubview:statusRow];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [content.topAnchor constraintEqualToAnchor:group.topAnchor constant:12],
+        [content.leadingAnchor constraintEqualToAnchor:group.leadingAnchor constant:12],
+        [content.trailingAnchor constraintEqualToAnchor:group.trailingAnchor constant:-12],
+        [content.bottomAnchor constraintEqualToAnchor:group.bottomAnchor constant:-12]
+    ]];
+    [self.stack addArrangedSubview:group];
+    if (function.length > 0) self.functionCards[function] = group;
+    return status;
+}
+
+- (UIButton *)actionButtonWithTitle:(NSString *)title action:(SEL)action {
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeSystem];
+    button.tintColor = UIColor.whiteColor;
+    button.accessibilityLabel = title;
+    [button addTarget:self action:action forControlEvents:UIControlEventTouchUpInside];
+    [button setContentHuggingPriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+    [button setContentCompressionResistancePriority:UILayoutPriorityRequired forAxis:UILayoutConstraintAxisHorizontal];
+    [button.heightAnchor constraintGreaterThanOrEqualToConstant:44].active = YES;
+
+    if (@available(iOS 15.0, *)) {
+        UIButtonConfiguration *configuration = [UIButtonConfiguration filledButtonConfiguration];
+        configuration.title = title;
+        configuration.image = [UIImage systemImageNamed:@"play.fill"];
+        configuration.imagePadding = 6;
+        configuration.baseForegroundColor = UIColor.whiteColor;
+        configuration.baseBackgroundColor = UIColor.systemBlueColor;
+        configuration.contentInsets = NSDirectionalEdgeInsetsMake(8, 12, 8, 12);
+        button.configuration = configuration;
+    } else {
+        [button setTitle:title forState:UIControlStateNormal];
+        [button setImage:[UIImage systemImageNamed:@"play.fill"] forState:UIControlStateNormal];
+        button.backgroundColor = UIColor.systemBlueColor;
+        [button setTitleColor:UIColor.whiteColor forState:UIControlStateNormal];
+        button.layer.cornerRadius = 8;
+        button.contentEdgeInsets = UIEdgeInsetsMake(8, 12, 8, 12);
+    }
+    return button;
+}
+
+- (void)addFunctionCard:(NSString *)function
+                 detail:(NSString *)detail
+           prerequisite:(NSString *)prerequisite
+                  action:(SEL)action {
+    UIView *card = [UIView new];
+    card.backgroundColor = [UIColor.secondarySystemBackgroundColor colorWithAlphaComponent:0.9];
+    card.layer.cornerRadius = 10;
+
+    UIStackView *content = [[UIStackView alloc] init];
+    content.axis = UILayoutConstraintAxisVertical;
+    content.spacing = 6;
+    content.translatesAutoresizingMaskIntoConstraints = NO;
+    [card addSubview:content];
+
+    UIStackView *topRow = [[UIStackView alloc] init];
+    topRow.axis = UILayoutConstraintAxisHorizontal;
+    topRow.alignment = UIStackViewAlignmentCenter;
+    topRow.spacing = 8;
+
+    UIStackView *info = [[UIStackView alloc] init];
+    info.axis = UILayoutConstraintAxisVertical;
+    info.spacing = 2;
+    UILabel *functionLabel = [self label:function style:UIFontTextStyleSubheadline];
+    functionLabel.font = [UIFont systemFontOfSize:functionLabel.font.pointSize weight:UIFontWeightSemibold];
+    UILabel *detailLabel = [self label:detail style:UIFontTextStyleCaption1];
+    detailLabel.textColor = UIColor.secondaryLabelColor;
+    detailLabel.numberOfLines = 0;
+    UILabel *prerequisiteLabel = [self label:prerequisite style:UIFontTextStyleCaption2];
+    prerequisiteLabel.textColor = UIColor.secondaryLabelColor;
+    prerequisiteLabel.numberOfLines = 0;
+    [info addArrangedSubview:functionLabel];
+    [info addArrangedSubview:detailLabel];
+    [info addArrangedSubview:prerequisiteLabel];
+
+    UIButton *runButton = [self actionButtonWithTitle:@"Run" action:action];
+    runButton.accessibilityLabel = function;
+    [topRow addArrangedSubview:info];
+    [topRow addArrangedSubview:runButton];
+    [content addArrangedSubview:topRow];
+
+    [NSLayoutConstraint activateConstraints:@[
+        [content.topAnchor constraintEqualToAnchor:card.topAnchor constant:10],
+        [content.leadingAnchor constraintEqualToAnchor:card.leadingAnchor constant:12],
+        [content.trailingAnchor constraintEqualToAnchor:card.trailingAnchor constant:-12],
+        [content.bottomAnchor constraintEqualToAnchor:card.bottomAnchor constant:-10]
+    ]];
+    [self.stack addArrangedSubview:card];
+    self.functionCards[function] = card;
+}
+
+- (NSDictionary *)taskBodyRequired {
+    NSInteger taskId = self.taskIdField.text.integerValue;
+    return @{ @"task_id": @(taskId) };
+}
+
+- (void)runFunction:(NSString *)function method:(CloudCodeHttpMethod)method query:(NSDictionary *)query body:(NSDictionary *)body {
+    if (self.spinner.isAnimating) return;
+    [self.spinner startAnimating];
+    [self prepareResultForFunction:function];
+    [self setResultText:[NSString stringWithFormat:@"Calling %@...", function]];
+    NSDate *started = [NSDate date];
+    __weak typeof(self) weakSelf = self;
+    [CloudCode call:function method:method query:query body:body headers:@{ @"X-Sample-Client": @"objc" } completion:^(CloudCodeResponse * _Nullable response, NSError * _Nullable error) {
+        NSTimeInterval elapsed = -[started timeIntervalSinceNow];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __strong typeof(weakSelf) self = weakSelf;
+            if (!self) return;
+            [self.spinner stopAnimating];
+            if (response) {
+                [self setResultText:[NSString stringWithFormat:@"HTTP %ld\nDuration: %.2f s\nrequestId: %@\nBody: %@", (long)response.statusCode, elapsed, response.requestId ?: @"none", [self jsonText:response.data]]];
+            } else {
+                [self setResultText:[NSString stringWithFormat:@"Duration: %.2f s\nError: %@", elapsed, error.localizedDescription ?: @"Unknown error"]];
+            }
+        });
+    }];
+}
+
+- (void)prepareResultForFunction:(NSString *)function {
+    self.resultTitleLabel.text = [NSString stringWithFormat:@"Result · %@", [self displayNameForFunction:function]];
+    self.resultExpanded = YES;
+    self.resultContainer.hidden = NO;
+
+    UIView *anchor = self.functionCards[function];
+    [self.stack removeArrangedSubview:self.resultContainer];
+    [self.resultContainer removeFromSuperview];
+
+    if (anchor) {
+        NSUInteger index = [self.stack.arrangedSubviews indexOfObject:anchor];
+        [self.stack insertArrangedSubview:self.resultContainer atIndex:index + 1];
+    } else {
+        [self.stack addArrangedSubview:self.resultContainer];
+    }
+}
+
+- (void)verifyBackend {
+    if (self.verifyingBackend) return;
+    self.verifyingBackend = YES;
+    self.databaseStatusLabel.text = @"Checking...";
+    self.cmsStatusLabel.text = @"Checking...";
+    self.databaseStatusLabel.textColor = UIColor.secondaryLabelColor;
+    self.cmsStatusLabel.textColor = UIColor.secondaryLabelColor;
+
+    __weak typeof(self) weakSelf = self;
+    [CloudCode call:@"cloud-demo-dashboard-summary"
+             method:CloudCodeHttpMethodGet
+              query:nil
+                body:nil
+             headers:@{ @"X-Sample-Client": @"objc" }
+          completion:^(CloudCodeResponse * _Nullable response, NSError * _Nullable error) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            __strong typeof(weakSelf) self = weakSelf;
+            if (!self) return;
+            self.verifyingBackend = NO;
+            if (!response || response.statusCode != 200 || ![response.data isKindOfClass:NSDictionary.class]) {
+                self.databaseStatusLabel.text = @"Not available";
+                self.cmsStatusLabel.text = @"Not available";
+                self.databaseStatusLabel.textColor = UIColor.secondaryLabelColor;
+                self.cmsStatusLabel.textColor = UIColor.secondaryLabelColor;
+                return;
+            }
+
+            NSDictionary *payload = (NSDictionary *)response.data;
+            BOOL databaseAvailable = payload[@"task_count"] != nil;
+            BOOL cmsAvailable = payload[@"posts"] != nil;
+            self.databaseStatusLabel.text = databaseAvailable ? @"Available" : @"Not available";
+            self.cmsStatusLabel.text = cmsAvailable ? @"Available" : @"Not available";
+            self.databaseStatusLabel.textColor = databaseAvailable ? UIColor.systemGreenColor : UIColor.secondaryLabelColor;
+            self.cmsStatusLabel.textColor = cmsAvailable ? UIColor.systemGreenColor : UIColor.secondaryLabelColor;
+        });
+    }];
+}
+
+- (void)toggleResult {
+    self.resultExpanded = !self.resultExpanded;
+    [self updateResultDisplay];
+}
+
+- (void)setResultText:(NSString *)text {
+    self.fullResultText = text ?: @"";
+    [self updateResultDisplay];
+}
+
+- (void)updateResultDisplay {
+    if (self.resultExpanded) {
+        self.resultLabel.text = self.fullResultText;
+        self.resultLabel.numberOfLines = 0;
+        [self.resultToggleButton setTitle:@"Collapse" forState:UIControlStateNormal];
+    } else {
+        NSArray<NSString *> *lines = [self.fullResultText componentsSeparatedByString:@"\n"];
+        NSArray<NSString *> *previewLines = [lines subarrayWithRange:NSMakeRange(0, MIN(lines.count, 2))];
+        self.resultLabel.text = [previewLines componentsJoinedByString:@"\n"];
+        self.resultLabel.numberOfLines = 2;
+        [self.resultToggleButton setTitle:@"Expand" forState:UIControlStateNormal];
+    }
+}
+
+- (void)confirmAndRun:(NSString *)title handler:(void (^)(void))handler {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title message:@"This calls a real backend operation." preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:nil]];
+    [alert addAction:[UIAlertAction actionWithTitle:@"Run" style:UIAlertActionStyleDestructive handler:^(__unused UIAlertAction *action) { handler(); }]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (void)createTask { [self runFunction:@"cloud-demo-create-task" method:CloudCodeHttpMethodPost query:nil body:@{ @"title": self.titleField.text ?: @"" }]; }
+- (void)createTables {
+    [self confirmAndRun:@"cloud-demo-setup-database" handler:^{
+        [self runFunction:@"cloud-demo-setup-database" method:CloudCodeHttpMethodPost query:nil body:nil];
+    }];
+}
+- (void)listTasks { [self runFunction:@"cloud-demo-list-tasks" method:CloudCodeHttpMethodGet query:@{ @"limit": @"20" } body:nil]; }
+- (void)completeTask { [self runFunction:@"cloud-demo-complete-task" method:CloudCodeHttpMethodPatch query:nil body:[self taskBodyRequired]]; }
+- (void)deleteTask {
+    [self confirmAndRun:@"cloud-demo-delete-task" handler:^{ [self runFunction:@"cloud-demo-delete-task" method:CloudCodeHttpMethodDelete query:nil body:[self taskBodyRequired]]; }];
+}
+- (void)inspectContext { [self runFunction:@"cloud-demo-http-inspector" method:CloudCodeHttpMethodPost query:@{ @"source": @"objc" } body:@{ @"message": @"hello", @"count": @2 }]; }
+- (void)jsonValues { [self runFunction:@"cloud-demo-json-values" method:CloudCodeHttpMethodPost query:nil body:nil]; }
+- (void)nullContract { [self runFunction:@"cloud-demo-null-contract" method:CloudCodeHttpMethodGet query:nil body:nil]; }
+- (void)responseShapes { [self runFunction:@"cloud-demo-response-shapes" method:CloudCodeHttpMethodPost query:nil body:nil]; }
+- (void)controlledError { [self runFunction:@"cloud-demo-error-response" method:CloudCodeHttpMethodPost query:nil body:@{ @"invalid": @YES }]; }
+- (void)timeoutDemo { [self runFunction:@"cloud-demo-timeout-10s" method:CloudCodeHttpMethodGet query:nil body:nil]; }
+- (void)readPosts {
+    NSDictionary *query = self.uuidField.text.length > 0 ? @{ @"uuid": self.uuidField.text } : nil;
+    [self runFunction:@"cloud-demo-read-posts" method:CloudCodeHttpMethodGet query:query body:nil];
+}
+- (void)createSampleContent {
+    [self confirmAndRun:@"cloud-demo-publish-post" handler:^{
+        [self runFunction:@"cloud-demo-publish-post" method:CloudCodeHttpMethodPost query:nil body:@{ @"title": self.publishTitleField.text ?: @"", @"body": self.publishBodyField.text ?: @"" }];
+    }];
+}
+- (void)runtimeContext { [self runFunction:@"cloud-demo-runtime-context" method:CloudCodeHttpMethodGet query:nil body:nil]; }
+- (void)sendPush {
+    [self confirmAndRun:@"cloud-demo-send-push" handler:^{
+        [self prepareResultForFunction:@"cloud-demo-send-push"];
+        [self setResultText:@"Checking notification permission..."];
+        [self ensurePushReady:^(BOOL ready) {
+            if (ready) {
+                [self runFunction:@"cloud-demo-send-push" method:CloudCodeHttpMethodPost query:nil body:@{ @"title": @"Cloud Code demo", @"body": @"Push from Objective-C sample" }];
+            }
+        }];
+    }];
+}
+- (void)createOrder { [self runFunction:@"cloud-demo-create-order" method:CloudCodeHttpMethodPost query:nil body:@{ @"idempotency_key": NSUUID.UUID.UUIDString, @"amount": @100 }]; }
+- (void)summary { [self runFunction:@"cloud-demo-dashboard-summary" method:CloudCodeHttpMethodGet query:nil body:nil]; }
+
+- (void)ensurePushReady:(void (^)(BOOL ready))completion {
+    // Keep the action safe if the host app did not initialize Push yet.
+    [PushNotifications start];
+    [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings *settings) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            UNAuthorizationStatus status = settings.authorizationStatus;
+            if (status == UNAuthorizationStatusNotDetermined) {
+                [PushNotifications requestNotificationPermissionWithListener:^(BOOL granted) {
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                        if (granted) {
+                            [PushNotifications setNotificationsEnabled:YES];
+                        } else {
+                            [self presentAlertWithTitle:@"Notification permission required"
+                                                message:@"Allow notifications in Settings before sending a push."];
+                        }
+                        if (completion) completion(granted);
+                    });
+                }];
+                return;
+            }
+
+            if (status == UNAuthorizationStatusAuthorized ||
+                status == UNAuthorizationStatusProvisional ||
+                status == UNAuthorizationStatusEphemeral) {
+                [PushNotifications setNotificationsEnabled:YES];
+                if (completion) completion(YES);
+                return;
+            }
+
+            [self presentAlertWithTitle:@"Notification permission required"
+                                message:@"Notifications are disabled in Settings. Enable them and try again."];
+            if (completion) completion(NO);
+        });
+    }];
+}
+
+- (NSString *)displayNameForFunction:(NSString *)function {
+    return function;
+}
+
+- (void)presentAlertWithTitle:(NSString *)title message:(NSString *)message {
+    UIAlertController *alert = [UIAlertController alertControllerWithTitle:title
+                                                                       message:message
+                                                                preferredStyle:UIAlertControllerStyleAlert];
+    [alert addAction:[UIAlertAction actionWithTitle:@"OK" style:UIAlertActionStyleCancel handler:nil]];
+    [self presentViewController:alert animated:YES completion:nil];
+}
+
+- (NSString *)jsonText:(id)value {
+    if (!value || value == [NSNull null]) return @"null";
+    if (![NSJSONSerialization isValidJSONObject:value]) return [value description];
+    NSData *data = [NSJSONSerialization dataWithJSONObject:value options:NSJSONWritingPrettyPrinted error:nil];
+    return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] ?: [value description];
+}
+
+@end

--- a/Samples/AppAmbit.App.ObjC/CloudCodeViewController.m
+++ b/Samples/AppAmbit.App.ObjC/CloudCodeViewController.m
@@ -50,7 +50,7 @@
     self.databaseStatusLabel = [self addSetupGroup:@"Database"
                                         requirement:@"Create Database first"
                                                tint:UIColor.systemBlueColor
-                                          function:@"cloud-demo-setup-database"
+                                           function:@"cloud-demo-setup-database-ios"
                                             action:@selector(createTables)];
 
     self.cmsStatusLabel = [self addSetupGroup:@"CMS"
@@ -69,27 +69,27 @@
     [self addSectionHeader:@"Database"];
     [self.stack addArrangedSubview:self.titleField];
     [self.stack addArrangedSubview:self.taskIdField];
-    [self addFunctionCard:@"cloud-demo-create-task"
+    [self addFunctionCard:@"cloud-demo-create-task-ios"
                    detail:@"Insert a task for the signed-in consumer."
-             prerequisite:@"Requires cloud_demo_tasks"
+              prerequisite:@"Requires cloud_demo_tasks_ios"
                     action:@selector(createTask)];
-    [self addFunctionCard:@"cloud-demo-list-tasks"
+    [self addFunctionCard:@"cloud-demo-list-tasks-ios"
                    detail:@"Read the current consumer's tasks."
-             prerequisite:@"Requires cloud_demo_tasks"
+              prerequisite:@"Requires cloud_demo_tasks_ios"
                     action:@selector(listTasks)];
-    [self addFunctionCard:@"cloud-demo-complete-task"
+    [self addFunctionCard:@"cloud-demo-complete-task-ios"
                    detail:@"Update one task with consumer ownership."
              prerequisite:@"Requires a task id"
                     action:@selector(completeTask)];
-    [self addFunctionCard:@"cloud-demo-delete-task"
+    [self addFunctionCard:@"cloud-demo-delete-task-ios"
                    detail:@"Delete one task owned by the consumer."
              prerequisite:@"Requires a task id and confirmation"
                     action:@selector(deleteTask)];
-    [self addFunctionCard:@"cloud-demo-create-order"
+    [self addFunctionCard:@"cloud-demo-create-order-ios"
                    detail:@"Create an order without duplicate idempotency keys."
-             prerequisite:@"Requires cloud_demo_orders"
+              prerequisite:@"Requires cloud_demo_orders_ios"
                     action:@selector(createOrder)];
-    [self addFunctionCard:@"cloud-demo-dashboard-summary"
+    [self addFunctionCard:@"cloud-demo-dashboard-summary-ios"
                    detail:@"Combine Database and CMS in one response."
              prerequisite:@"Requires Database and CMS setup"
                     action:@selector(summary)];
@@ -98,19 +98,19 @@
     [self.stack addArrangedSubview:self.uuidField];
     [self.stack addArrangedSubview:self.publishTitleField];
     [self.stack addArrangedSubview:self.publishBodyField];
-    [self addFunctionCard:@"cloud-demo-publish-post"
+    [self addFunctionCard:@"cloud-demo-publish-post-ios"
                    detail:@"Create a published CMS entry."
-             prerequisite:@"Requires confirmation and cloud_code_demo_posts"
+              prerequisite:@"Requires confirmation and cloud_code_demo_posts_ios"
                     action:@selector(createSampleContent)];
-    [self addFunctionCard:@"cloud-demo-read-posts"
+    [self addFunctionCard:@"cloud-demo-read-posts-ios"
                    detail:@"List published entries using only CMS data."
-             prerequisite:@"Requires cloud_code_demo_posts"
+              prerequisite:@"Requires cloud_code_demo_posts_ios"
                     action:@selector(readPosts)];
 
     [self addSectionHeader:@"Push"];
-    [self addFunctionCard:@"cloud-demo-send-push"
+    [self addFunctionCard:@"cloud-demo-send-push-ios"
                    detail:@"Send a notification to all consumers."
-             prerequisite:@"Requires permission and APNs/FCM"
+              prerequisite:@"Requires permission and APNs"
                     action:@selector(sendPush)];
 
     [self addSectionHeader:@"HTTP"];
@@ -389,7 +389,7 @@
     self.cmsStatusLabel.textColor = UIColor.secondaryLabelColor;
 
     __weak typeof(self) weakSelf = self;
-    [CloudCode call:@"cloud-demo-dashboard-summary"
+     [CloudCode call:@"cloud-demo-dashboard-summary-ios"
              method:CloudCodeHttpMethodGet
               query:nil
                 body:nil
@@ -449,16 +449,16 @@
     [self presentViewController:alert animated:YES completion:nil];
 }
 
-- (void)createTask { [self runFunction:@"cloud-demo-create-task" method:CloudCodeHttpMethodPost query:nil body:@{ @"title": self.titleField.text ?: @"" }]; }
+- (void)createTask { [self runFunction:@"cloud-demo-create-task-ios" method:CloudCodeHttpMethodPost query:nil body:@{ @"title": self.titleField.text ?: @"" }]; }
 - (void)createTables {
-    [self confirmAndRun:@"cloud-demo-setup-database" handler:^{
-        [self runFunction:@"cloud-demo-setup-database" method:CloudCodeHttpMethodPost query:nil body:nil];
+     [self confirmAndRun:@"cloud-demo-setup-database-ios" handler:^{
+         [self runFunction:@"cloud-demo-setup-database-ios" method:CloudCodeHttpMethodPost query:nil body:nil];
     }];
 }
-- (void)listTasks { [self runFunction:@"cloud-demo-list-tasks" method:CloudCodeHttpMethodGet query:@{ @"limit": @"20" } body:nil]; }
-- (void)completeTask { [self runFunction:@"cloud-demo-complete-task" method:CloudCodeHttpMethodPatch query:nil body:[self taskBodyRequired]]; }
+- (void)listTasks { [self runFunction:@"cloud-demo-list-tasks-ios" method:CloudCodeHttpMethodGet query:@{ @"limit": @"20" } body:nil]; }
+- (void)completeTask { [self runFunction:@"cloud-demo-complete-task-ios" method:CloudCodeHttpMethodPatch query:nil body:[self taskBodyRequired]]; }
 - (void)deleteTask {
-    [self confirmAndRun:@"cloud-demo-delete-task" handler:^{ [self runFunction:@"cloud-demo-delete-task" method:CloudCodeHttpMethodDelete query:nil body:[self taskBodyRequired]]; }];
+     [self confirmAndRun:@"cloud-demo-delete-task-ios" handler:^{ [self runFunction:@"cloud-demo-delete-task-ios" method:CloudCodeHttpMethodDelete query:nil body:[self taskBodyRequired]]; }];
 }
 - (void)inspectContext { [self runFunction:@"cloud-demo-http-inspector" method:CloudCodeHttpMethodPost query:@{ @"source": @"objc" } body:@{ @"message": @"hello", @"count": @2 }]; }
 - (void)jsonValues { [self runFunction:@"cloud-demo-json-values" method:CloudCodeHttpMethodPost query:nil body:nil]; }
@@ -468,27 +468,27 @@
 - (void)timeoutDemo { [self runFunction:@"cloud-demo-timeout-10s" method:CloudCodeHttpMethodGet query:nil body:nil]; }
 - (void)readPosts {
     NSDictionary *query = self.uuidField.text.length > 0 ? @{ @"uuid": self.uuidField.text } : nil;
-    [self runFunction:@"cloud-demo-read-posts" method:CloudCodeHttpMethodGet query:query body:nil];
+     [self runFunction:@"cloud-demo-read-posts-ios" method:CloudCodeHttpMethodGet query:query body:nil];
 }
 - (void)createSampleContent {
-    [self confirmAndRun:@"cloud-demo-publish-post" handler:^{
-        [self runFunction:@"cloud-demo-publish-post" method:CloudCodeHttpMethodPost query:nil body:@{ @"title": self.publishTitleField.text ?: @"", @"body": self.publishBodyField.text ?: @"" }];
+     [self confirmAndRun:@"cloud-demo-publish-post-ios" handler:^{
+         [self runFunction:@"cloud-demo-publish-post-ios" method:CloudCodeHttpMethodPost query:nil body:@{ @"title": self.publishTitleField.text ?: @"", @"body": self.publishBodyField.text ?: @"" }];
     }];
 }
 - (void)runtimeContext { [self runFunction:@"cloud-demo-runtime-context" method:CloudCodeHttpMethodGet query:nil body:nil]; }
 - (void)sendPush {
-    [self confirmAndRun:@"cloud-demo-send-push" handler:^{
-        [self prepareResultForFunction:@"cloud-demo-send-push"];
+     [self confirmAndRun:@"cloud-demo-send-push-ios" handler:^{
+         [self prepareResultForFunction:@"cloud-demo-send-push-ios"];
         [self setResultText:@"Checking notification permission..."];
         [self ensurePushReady:^(BOOL ready) {
             if (ready) {
-                [self runFunction:@"cloud-demo-send-push" method:CloudCodeHttpMethodPost query:nil body:@{ @"title": @"Cloud Code demo", @"body": @"Push from Objective-C sample" }];
+                 [self runFunction:@"cloud-demo-send-push-ios" method:CloudCodeHttpMethodPost query:nil body:@{ @"title": @"Cloud Code iOS demo", @"body": @"Push from Objective-C sample" }];
             }
         }];
     }];
 }
-- (void)createOrder { [self runFunction:@"cloud-demo-create-order" method:CloudCodeHttpMethodPost query:nil body:@{ @"idempotency_key": NSUUID.UUID.UUIDString, @"amount": @100 }]; }
-- (void)summary { [self runFunction:@"cloud-demo-dashboard-summary" method:CloudCodeHttpMethodGet query:nil body:nil]; }
+- (void)createOrder { [self runFunction:@"cloud-demo-create-order-ios" method:CloudCodeHttpMethodPost query:nil body:@{ @"idempotency_key": NSUUID.UUID.UUIDString, @"amount": @100 }]; }
+- (void)summary { [self runFunction:@"cloud-demo-dashboard-summary-ios" method:CloudCodeHttpMethodGet query:nil body:nil]; }
 
 - (void)ensurePushReady:(void (^)(BOOL ready))completion {
     // Keep the action safe if the host app did not initialize Push yet.

--- a/Samples/AppAmbit.App.ObjC/MainTabBarController.m
+++ b/Samples/AppAmbit.App.ObjC/MainTabBarController.m
@@ -4,6 +4,7 @@
 #import "RemoteConfigViewController.h"
 #import "CmsViewController.h"
 #import "DatabaseViewController.h"
+#import "CloudCodeViewController.h"
 
 #pragma mark - TabBarItemView
 
@@ -99,10 +100,14 @@
     database.title = @"Database";
     UINavigationController *navDatabase = [[UINavigationController alloc] initWithRootViewController:database];
 
-    self.tabControllers = @[navCrashes, navAnalytics, navRemoteConfig, navCms, navDatabase];
+    CloudCodeViewController *cloudCode = [CloudCodeViewController new];
+    cloudCode.title = @"Cloud Code";
+    UINavigationController *navCloudCode = [[UINavigationController alloc] initWithRootViewController:cloudCode];
 
-    NSArray<NSString *> *titles = @[@"Crashes", @"Analytics", @"RemoteConfig", @"CMS", @"Database"];
-    NSArray<NSString *> *icons = @[@"exclamationmark.triangle", @"chart.bar", @"arrow.2.circlepath.circle", @"doc.richtext", @"cylinder.split.1x2"];
+    self.tabControllers = @[navCrashes, navAnalytics, navRemoteConfig, navCms, navDatabase, navCloudCode];
+
+    NSArray<NSString *> *titles = @[@"Crashes", @"Analytics", @"RemoteConfig", @"CMS", @"Database", @"Cloud Code"];
+    NSArray<NSString *> *icons = @[@"exclamationmark.triangle", @"chart.bar", @"arrow.2.circlepath.circle", @"doc.richtext", @"cylinder.split.1x2", @"cloud.bolt"];
 
     [self setupContainerAndTabBar];
     [self setupTabButtonsWithTitles:titles icons:icons];

--- a/Samples/AppAmbit.App.Swift/CloudCodeView.swift
+++ b/Samples/AppAmbit.App.Swift/CloudCodeView.swift
@@ -446,8 +446,8 @@ struct CloudCodeView: View {
             isRunning = false
             if let result {
                 let data: [String: Any] = [
-                    "task_count": result.data.taskCount ?? NSNull(),
-                    "posts": result.data.posts?.map { $0.toAny() } ?? []
+                    "task_count": result.data?.taskCount ?? NSNull(),
+                    "posts": result.data?.posts?.map { $0.toAny() } ?? []
                 ]
                 resultText = "HTTP \(result.statusCode)\nDuration: \(formatDuration(elapsed))\nrequestId: \(result.requestId ?? "none")\nBody: \(jsonText(data))"
             } else if let error {

--- a/Samples/AppAmbit.App.Swift/CloudCodeView.swift
+++ b/Samples/AppAmbit.App.Swift/CloudCodeView.swift
@@ -19,6 +19,7 @@ struct CloudCodeView: View {
     @State private var databaseStatus = "Not available"
     @State private var cmsStatus = "Not available"
     @State private var databaseAvailable = false
+    @State private var databaseTablesReady = false
     @State private var cmsAvailable = false
     @State private var isVerifyingBackend = false
 
@@ -50,24 +51,40 @@ struct CloudCodeView: View {
                      GroupBox("Database") {
                          VStack(alignment: .leading, spacing: 8) {
                              setupRequirement("Create Database first", tint: .blue)
-                             HStack(spacing: 8) {
-                                 Label(databaseStatus, systemImage: databaseAvailable ? "checkmark.circle.fill" : "xmark.circle")
-                                     .font(.caption.weight(.semibold))
-                                     .foregroundColor(databaseAvailable ? .green : .secondary)
-                                 Spacer()
-                                 if isVerifyingBackend {
-                                     ProgressView()
-                                         .controlSize(.small)
-                                 }
+                              HStack(spacing: 8) {
+                                  Label(databaseStatus, systemImage: databaseAvailable ? "checkmark.circle.fill" : "xmark.circle")
+                                      .font(.caption.weight(.semibold))
+                                      .foregroundColor(databaseAvailable ? .green : .secondary)
+                                  Spacer()
+                                  if isVerifyingBackend {
+                                      ProgressView()
+                                          .controlSize(.small)
+                                  }
+                              }
+                              HStack(alignment: .firstTextBaseline) {
+                                  VStack(alignment: .leading, spacing: 2) {
+                                      Text("cloud-demo-setup-database-ios")
+                                          .font(.subheadline.weight(.semibold))
+                                      Text("Provision the app database before using database demos.")
+                                          .font(.caption)
+                                          .foregroundColor(.secondary)
+                                  }
+                                  Spacer(minLength: 8)
                                   Button {
                                       runOrConfirm(.setupDatabase, demoID: "setup-database")
                                   } label: {
-                                      Label("cloud-demo-setup-database-ios", systemImage: "play.fill")
+                                      Label("Run", systemImage: "play.fill")
                                   }
-                                 .buttonStyle(.borderedProminent)
-                                 .disabled(isRunning || isVerifyingBackend)
-                             }
-                             resultCard(for: "setup-database")
+                                  .buttonStyle(.borderedProminent)
+                                  .frame(minWidth: 44, minHeight: 44)
+                                  .disabled(isRunning || isVerifyingBackend || !databaseAvailable || databaseTablesReady)
+                              }
+                              .padding(.horizontal, 12)
+                              .padding(.vertical, 8)
+                              .frame(maxWidth: .infinity, alignment: .leading)
+                              .background(Color.secondary.opacity(0.08))
+                              .clipShape(RoundedRectangle(cornerRadius: 10))
+                              resultCard(for: "setup-database")
                          }
                          .frame(maxWidth: .infinity, alignment: .leading)
                      }
@@ -229,25 +246,37 @@ struct CloudCodeView: View {
         ) { response, error in
             DispatchQueue.main.async {
                 isVerifyingBackend = false
-                guard let response, response.statusCode == 200,
-                      let payload = response.data as? [String: Any] else {
-                    databaseAvailable = false
-                    cmsAvailable = false
-                    databaseStatus = "Not available"
-                    cmsStatus = "Not available"
+                 guard let response, response.statusCode == 200,
+                       let payload = response.data as? [String: Any] else {
+                     databaseAvailable = false
+                     databaseTablesReady = false
+                     cmsAvailable = false
+                     databaseStatus = "Not available"
+                     cmsStatus = "Not available"
                     return
                 }
 
-                databaseAvailable = payload["task_count"] != nil
-                cmsAvailable = payload["posts"] != nil
-                databaseStatus = databaseAvailable ? "Available" : "Not available"
-                cmsStatus = cmsAvailable ? "Available" : "Not available"
-                _ = error
+                 databaseAvailable = payload["database_available"] as? Bool ?? false
+                 databaseTablesReady = payload["database_tables_ready"] as? Bool ?? false
+                 cmsAvailable = payload["posts"] != nil
+                 if !databaseAvailable {
+                     databaseStatus = "Not available"
+                 } else if databaseTablesReady {
+                     databaseStatus = "Tables ready"
+                 } else {
+                     databaseStatus = "Available"
+                 }
+                 cmsStatus = cmsAvailable ? "Available" : "Not available"
+                 _ = error
             }
         }
     }
 
     private func runOrConfirm(_ action: CloudCodeDemoAction, demoID: String) {
+        if action == .setupDatabase && (!databaseAvailable || databaseTablesReady) {
+            return
+        }
+
         switch action {
         case .deleteTask, .publishPost, .push:
             pendingConfirmation = action

--- a/Samples/AppAmbit.App.Swift/CloudCodeView.swift
+++ b/Samples/AppAmbit.App.Swift/CloudCodeView.swift
@@ -1,0 +1,461 @@
+import SwiftUI
+import AppAmbit
+import AppAmbitPushNotifications
+import UserNotifications
+
+struct CloudCodeView: View {
+    @State private var taskTitle = "Buy coffee"
+    @State private var taskId = ""
+    @State private var postUUID = ""
+    @State private var publishTitle = "Cloud Code sample post"
+    @State private var publishBody = "Published through an HTTP Cloud Function."
+    @State private var isRunning = false
+    @State private var lastResultDemoID: String?
+    @State private var resultText = "No Cloud Code request yet."
+    @State private var resultTitle = "Latest result"
+    @State private var isResultExpanded = true
+    @State private var pendingConfirmation: CloudCodeDemoAction?
+    @State private var pendingConfirmationDemoID: String?
+    @State private var databaseStatus = "Not available"
+    @State private var cmsStatus = "Not available"
+    @State private var databaseAvailable = false
+    @State private var cmsAvailable = false
+    @State private var isVerifyingBackend = false
+
+    private let sectionNames = ["Database", "CMS", "Push", "HTTP"]
+
+    private let demos: [CloudCodeDemo] = [
+        CloudCodeDemo(id: "create-task", section: "Database", title: "Create task", slug: "cloud-demo-create-task", detail: "Insert a task for the signed-in consumer.", prerequisite: "cloud_demo_tasks", action: .createTask),
+        CloudCodeDemo(id: "list-tasks", section: "Database", title: "List tasks", slug: "cloud-demo-list-tasks", detail: "Read the current consumer's tasks.", prerequisite: "cloud_demo_tasks", action: .listTasks),
+        CloudCodeDemo(id: "complete-task", section: "Database", title: "Complete task", slug: "cloud-demo-complete-task", detail: "Update one task with consumer ownership.", prerequisite: "Task id", action: .completeTask),
+        CloudCodeDemo(id: "delete-task", section: "Database", title: "Delete task", slug: "cloud-demo-delete-task", detail: "Delete one task owned by the consumer.", prerequisite: "Task id + confirmation", action: .deleteTask),
+        CloudCodeDemo(id: "order", section: "Database", title: "Create idempotent order", slug: "cloud-demo-create-order", detail: "Create an order without duplicate idempotency keys.", prerequisite: "cloud_demo_orders", action: .createOrder),
+        CloudCodeDemo(id: "summary", section: "Database", title: "Dashboard summary", slug: "cloud-demo-dashboard-summary", detail: "Combine Database and CMS in one typed response.", prerequisite: "Database + CMS", action: .summary),
+        CloudCodeDemo(id: "create-sample-content", section: "CMS", title: "Create sample content", slug: "cloud-demo-publish-post", detail: "Create a published CMS entry.", prerequisite: "Confirmation", action: .publishPost),
+        CloudCodeDemo(id: "read-posts", section: "CMS", title: "Read CMS posts", slug: "cloud-demo-read-posts", detail: "List published entries using only CMS data.", prerequisite: "cloud_code_demo_posts", action: .readPosts),
+        CloudCodeDemo(id: "push", section: "Push", title: "Send push notification", slug: "cloud-demo-send-push", detail: "Send a notification to all consumers.", prerequisite: "Permission + APNs/FCM", action: .push),
+        CloudCodeDemo(id: "inspector", section: "HTTP", title: "Inspect HTTP context", slug: "cloud-demo-http-inspector", detail: "Inspect method, query, body and consumer context.", prerequisite: "HTTP trigger", action: .inspector),
+        CloudCodeDemo(id: "json-values", section: "HTTP", title: "JSON values", slug: "cloud-demo-json-values", detail: "Return common JSON value types.", prerequisite: "HTTP trigger", action: .jsonValues),
+        CloudCodeDemo(id: "null-contract", section: "HTTP", title: "Null contract", slug: "cloud-demo-null-contract", detail: "Compare raw null and an explicit value.", prerequisite: "HTTP trigger", action: .nullContract),
+        CloudCodeDemo(id: "response-shapes", section: "HTTP", title: "HTTP response shapes", slug: "cloud-demo-response-shapes", detail: "Demonstrate statuses, body and headers.", prerequisite: "HTTP trigger", action: .responseShapes),
+        CloudCodeDemo(id: "controlled-error", section: "HTTP", title: "Controlled error", slug: "cloud-demo-error-response", detail: "Return a safe client error response.", prerequisite: "HTTP trigger", action: .controlledError),
+        CloudCodeDemo(id: "timeout", section: "HTTP", title: "Backend timeout", slug: "cloud-demo-timeout-10s", detail: "Observe the configured function timeout.", prerequisite: "Function timeout = 10 s", action: .timeout),
+        CloudCodeDemo(id: "runtime-context", section: "HTTP", title: "Runtime context", slug: "cloud-demo-runtime-context", detail: "Use environment values, secrets and logs safely.", prerequisite: "DEMO_REGION + DEMO_SECRET", action: .runtimeContext),
+    ]
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                     GroupBox("Database") {
+                         VStack(alignment: .leading, spacing: 8) {
+                             setupRequirement("Create Database first", tint: .blue)
+                             HStack(spacing: 8) {
+                                 Label(databaseStatus, systemImage: databaseAvailable ? "checkmark.circle.fill" : "xmark.circle")
+                                     .font(.caption.weight(.semibold))
+                                     .foregroundColor(databaseAvailable ? .green : .secondary)
+                                 Spacer()
+                                 if isVerifyingBackend {
+                                     ProgressView()
+                                         .controlSize(.small)
+                                 }
+                                  Button {
+                                      runOrConfirm(.setupDatabase, demoID: "setup-database")
+                                  } label: {
+                                      Label("cloud-demo-setup-database", systemImage: "play.fill")
+                                  }
+                                 .buttonStyle(.borderedProminent)
+                                 .disabled(isRunning || isVerifyingBackend)
+                             }
+                             resultCard(for: "setup-database")
+                         }
+                         .frame(maxWidth: .infinity, alignment: .leading)
+                     }
+
+                      GroupBox("CMS") {
+                          VStack(alignment: .leading, spacing: 10) {
+                              setupRequirement("Create Content Type first", tint: .purple)
+                             HStack(spacing: 8) {
+                                 Label(cmsStatus, systemImage: cmsAvailable ? "checkmark.circle.fill" : "xmark.circle")
+                                     .font(.caption.weight(.semibold))
+                                     .foregroundColor(cmsAvailable ? .green : .secondary)
+                                 Spacer()
+                                 if isVerifyingBackend {
+                                     ProgressView()
+                                         .controlSize(.small)
+                                 }
+                             }
+                         }
+                         .frame(maxWidth: .infinity, alignment: .leading)
+                     }
+
+                     ForEach(sectionNames, id: \.self) { section in
+                         VStack(alignment: .leading, spacing: 8) {
+                             Text(section)
+                                 .font(.headline)
+                                 .padding(.top, 2)
+
+                             if section == "Database" {
+                                 VStack(spacing: 10) {
+                                     TextField("Task title", text: $taskTitle)
+                                         .textFieldStyle(.roundedBorder)
+                                     TextField("Task id for update/delete", text: $taskId)
+                                         .keyboardType(.numberPad)
+                                         .textFieldStyle(.roundedBorder)
+                                 }
+                             }
+
+                             if section == "CMS" {
+                                 VStack(spacing: 10) {
+                                     TextField("CMS post UUID", text: $postUUID)
+                                         .textFieldStyle(.roundedBorder)
+                                     TextField("Sample title", text: $publishTitle)
+                                         .textFieldStyle(.roundedBorder)
+                                     TextField("Sample body", text: $publishBody, axis: .vertical)
+                                         .lineLimit(3...6)
+                                         .textFieldStyle(.roundedBorder)
+                                 }
+                             }
+
+                             ForEach(demos.filter { $0.section == section }) { demo in
+                                VStack(alignment: .leading, spacing: 6) {
+                                    HStack(alignment: .firstTextBaseline) {
+                                         VStack(alignment: .leading, spacing: 2) {
+                                             Text(demo.slug)
+                                                 .font(.subheadline.weight(.semibold))
+                                             Text(demo.detail)
+                                                 .font(.caption)
+                                                 .foregroundColor(.secondary)
+                                        }
+                                        Spacer(minLength: 8)
+                                        if let action = demo.action {
+                                            Button {
+                                                runOrConfirm(action, demoID: demo.id)
+                                            } label: {
+                                                Label("Run", systemImage: "play.fill")
+                                            }
+                                            .buttonStyle(.borderedProminent)
+                                            .frame(minWidth: 44, minHeight: 44)
+                                            .disabled(isRunning)
+                                        } else {
+                                            Text("Dashboard")
+                                                .font(.caption.weight(.semibold))
+                                                .foregroundColor(.secondary)
+                                        }
+                                    }
+                                     Text(demo.prerequisite)
+                                         .font(.caption2.monospaced())
+                                         .foregroundColor(.secondary)
+                                }
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 8)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .background(Color.secondary.opacity(0.08))
+                                .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                                 resultCard(for: demo.id)
+                            }
+                        }
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Cloud Code")
+            .navigationBarTitleDisplayMode(.inline)
+            .onAppear {
+                 if databaseStatus == "Not available" && cmsStatus == "Not available" {
+                     verifyBackend()
+                 }
+            }
+            .overlay {
+                if isRunning {
+                    ProgressView("Calling Cloud Code...")
+                        .padding()
+                        .background(.regularMaterial)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+            }
+            .alert("Confirm Cloud Code action", isPresented: confirmationBinding) {
+                Button("Cancel", role: .cancel) {
+                    pendingConfirmation = nil
+                    pendingConfirmationDemoID = nil
+                }
+                Button("Run", role: .destructive) {
+                    let action = pendingConfirmation
+                    let demoID = pendingConfirmationDemoID
+                    pendingConfirmation = nil
+                    pendingConfirmationDemoID = nil
+                    if let action, let demoID { run(action, demoID: demoID) }
+                }
+            } message: {
+                Text("This calls a real backend operation. Continue only if the required service is configured.")
+            }
+        }
+    }
+
+    private var confirmationBinding: Binding<Bool> {
+        Binding(
+            get: { pendingConfirmation != nil },
+            set: {
+                if !$0 {
+                    pendingConfirmation = nil
+                    pendingConfirmationDemoID = nil
+                }
+            }
+        )
+    }
+
+    private func setupRequirement(_ text: String, tint: Color) -> some View {
+        Text(text)
+            .font(.caption2.weight(.semibold))
+            .foregroundColor(tint)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(tint.opacity(0.12))
+            .clipShape(Capsule())
+    }
+
+    private func verifyBackend() {
+        guard !isVerifyingBackend else { return }
+        isVerifyingBackend = true
+        databaseStatus = "Checking..."
+        cmsStatus = "Checking..."
+        CloudCode.call(
+            "cloud-demo-dashboard-summary",
+            method: .get,
+            query: nil,
+            body: nil,
+            headers: ["X-Sample-Client": "swift"]
+        ) { response, error in
+            DispatchQueue.main.async {
+                isVerifyingBackend = false
+                guard let response, response.statusCode == 200,
+                      let payload = response.data as? [String: Any] else {
+                    databaseAvailable = false
+                    cmsAvailable = false
+                    databaseStatus = "Not available"
+                    cmsStatus = "Not available"
+                    return
+                }
+
+                databaseAvailable = payload["task_count"] != nil
+                cmsAvailable = payload["posts"] != nil
+                databaseStatus = databaseAvailable ? "Available" : "Not available"
+                cmsStatus = cmsAvailable ? "Available" : "Not available"
+                _ = error
+            }
+        }
+    }
+
+    private func runOrConfirm(_ action: CloudCodeDemoAction, demoID: String) {
+        switch action {
+        case .deleteTask, .publishPost, .push:
+            pendingConfirmation = action
+            pendingConfirmationDemoID = demoID
+        default:
+            run(action, demoID: demoID)
+        }
+    }
+
+    private func run(_ action: CloudCodeDemoAction, demoID: String) {
+        guard !isRunning else { return }
+        lastResultDemoID = demoID
+        if [.completeTask, .deleteTask].contains(where: { sameAction($0, action) }), Int(taskId) == nil {
+            resultText = "Enter a numeric task id first."
+            resultTitle = "Input required"
+            isResultExpanded = true
+            return
+        }
+
+        let configuration = requestConfiguration(for: action)
+        isRunning = true
+        resultTitle = "Latest result · \(configuration.slug)"
+        resultText = "Calling \(configuration.slug)..."
+        isResultExpanded = true
+        let started = Date()
+
+        if action == .push {
+            ensurePushReady { granted in
+                DispatchQueue.main.async {
+                    guard self.isRunning else { return }
+                    if granted {
+                        self.call(action, configuration: configuration, started: started)
+                    } else {
+                        self.isRunning = false
+                        self.resultText = "Notification permission is required. Enable notifications in Settings and try again."
+                    }
+                }
+            }
+        } else {
+            call(action, configuration: configuration, started: started)
+        }
+    }
+
+    private func call(_ action: CloudCodeDemoAction, configuration: (slug: String, method: CloudCodeHttpMethod, query: [String: String]?, body: [String: Any]?, headers: [String: String]?), started: Date) {
+        if action == .summary {
+            CloudCode.call(
+                configuration.slug,
+                method: configuration.method,
+                query: configuration.query,
+                body: configuration.body,
+                headers: configuration.headers,
+                as: DashboardSummary.self
+            ) { result, error in
+                DispatchQueue.main.async {
+                    self.finishTyped(result: result, error: error, started: started)
+                }
+            }
+            return
+        }
+
+        CloudCode.call(
+            configuration.slug,
+            method: configuration.method,
+            query: configuration.query,
+            body: configuration.body,
+            headers: configuration.headers
+        ) { response, error in
+            let elapsed = Date().timeIntervalSince(started)
+            DispatchQueue.main.async {
+                self.isRunning = false
+                self.resultText = self.format(response: response, error: error, elapsed: elapsed)
+            }
+        }
+    }
+
+    private func ensurePushReady(completion: @escaping (Bool) -> Void) {
+        // Keep this path safe if the host app did not initialize Push yet.
+        PushNotifications.start(debugMode: true)
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
+            let hasPermission = settings.authorizationStatus == .authorized || settings.authorizationStatus == .provisional
+
+            DispatchQueue.main.async {
+                if hasPermission {
+                    PushNotifications.setNotificationsEnabled(true)
+                    completion(true)
+                    return
+                }
+
+                if settings.authorizationStatus == .notDetermined {
+                    PushNotifications.requestNotificationPermission { granted in
+                        DispatchQueue.main.async {
+                            if granted {
+                                PushNotifications.setNotificationsEnabled(true)
+                            }
+                            completion(granted)
+                        }
+                    }
+                    return
+                }
+
+                completion(false)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func resultCard(for demoID: String) -> some View {
+        if lastResultDemoID == demoID {
+            GroupBox {
+                DisclosureGroup(isExpanded: $isResultExpanded) {
+                    ScrollView([.horizontal, .vertical], showsIndicators: true) {
+                        Text(resultText)
+                            .font(.system(.caption, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .textSelection(.enabled)
+                            .padding(.top, 6)
+                    }
+                    .frame(maxHeight: 240)
+                } label: {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(resultTitle)
+                            .font(.subheadline.weight(.semibold))
+                        Text(isResultExpanded ? "Tap to collapse" : "Tap to expand the response")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .padding(.top, 2)
+        }
+    }
+
+    private func sameAction(_ lhs: CloudCodeDemoAction, _ rhs: CloudCodeDemoAction) -> Bool {
+        switch (lhs, rhs) {
+        case (.completeTask, .completeTask), (.deleteTask, .deleteTask): return true
+        default: return false
+        }
+    }
+
+    private func requestConfiguration(for action: CloudCodeDemoAction) -> (slug: String, method: CloudCodeHttpMethod, query: [String: String]?, body: [String: Any]?, headers: [String: String]?) {
+        let taskValue = Int(taskId) ?? 0
+        let headers = ["X-Sample-Client": "swift"]
+        switch action {
+        case .setupDatabase: return ("cloud-demo-setup-database", .post, nil, nil, headers)
+        case .createTask: return ("cloud-demo-create-task", .post, nil, ["title": taskTitle], headers)
+        case .listTasks: return ("cloud-demo-list-tasks", .get, ["limit": "20"], nil, headers)
+        case .completeTask: return ("cloud-demo-complete-task", .patch, nil, ["task_id": taskValue], headers)
+        case .deleteTask: return ("cloud-demo-delete-task", .delete, nil, ["task_id": taskValue], headers)
+        case .inspector: return ("cloud-demo-http-inspector", .post, ["source": "swift"], ["message": "hello", "count": 2], headers)
+        case .jsonValues: return ("cloud-demo-json-values", .post, nil, nil, headers)
+        case .nullContract: return ("cloud-demo-null-contract", .get, nil, nil, headers)
+        case .responseShapes: return ("cloud-demo-response-shapes", .post, nil, nil, headers)
+        case .controlledError: return ("cloud-demo-error-response", .post, nil, ["invalid": true], headers)
+        case .timeout: return ("cloud-demo-timeout-10s", .get, nil, nil, headers)
+        case .readPosts: return ("cloud-demo-read-posts", .get, postUUID.isEmpty ? nil : ["uuid": postUUID], nil, headers)
+        case .publishPost: return ("cloud-demo-publish-post", .post, nil, ["title": publishTitle, "body": publishBody], headers)
+        case .runtimeContext: return ("cloud-demo-runtime-context", .get, nil, nil, headers)
+        case .push: return ("cloud-demo-send-push", .post, nil, ["title": "Cloud Code demo", "body": "Push from Swift sample"], headers)
+        case .createOrder: return ("cloud-demo-create-order", .post, nil, ["idempotency_key": UUID().uuidString, "amount": 100], headers)
+        case .summary: return ("cloud-demo-dashboard-summary", .get, nil, nil, headers)
+        }
+    }
+
+    private func finishTyped(result: CloudCodeResult<DashboardSummary>?, error: CloudCodeError?, started: Date) {
+        let elapsed = Date().timeIntervalSince(started)
+        DispatchQueue.main.async {
+            isRunning = false
+            if let result {
+                let data: [String: Any] = [
+                    "task_count": result.data.taskCount ?? NSNull(),
+                    "posts": result.data.posts?.map { $0.toAny() } ?? []
+                ]
+                resultText = "HTTP \(result.statusCode)\nDuration: \(formatDuration(elapsed))\nrequestId: \(result.requestId ?? "none")\nBody: \(jsonText(data))"
+            } else if let error {
+                resultText = "Duration: \(formatDuration(elapsed))\nError: \(error.localizedDescription)"
+            } else {
+                resultText = "HTTP 204\nDuration: \(formatDuration(elapsed))\nBody: No content"
+            }
+        }
+    }
+
+    private func format(response: CloudCodeResponse?, error: Error?, elapsed: TimeInterval) -> String {
+        if let response {
+            return "HTTP \(response.statusCode)\nDuration: \(formatDuration(elapsed))\nrequestId: \(response.requestId ?? "none")\nBody: \(jsonText(response.data))"
+        }
+        if let cloudError = error as? CloudCodeError {
+            switch cloudError {
+            case .http(_, let body, let rawBody, let requestId):
+                let bodyText = body.map { jsonText($0.toAny()) } ?? rawBody ?? "none"
+                return "Duration: \(formatDuration(elapsed))\nrequestId: \(requestId ?? "none")\nHTTP error body: \(bodyText)\nError: \(cloudError.localizedDescription)"
+            default:
+                break
+            }
+        }
+        return "Duration: \(formatDuration(elapsed))\nError: \(error?.localizedDescription ?? "Unknown error")"
+    }
+
+    private func formatDuration(_ duration: TimeInterval) -> String {
+        String(format: "%.2f s", duration)
+    }
+
+    private func jsonText(_ value: Any) -> String {
+        if value is NSNull { return "null" }
+        guard JSONSerialization.isValidJSONObject(value),
+              let data = try? JSONSerialization.data(withJSONObject: value, options: [.prettyPrinted]),
+              let string = String(data: data, encoding: .utf8) else {
+            return String(describing: value)
+        }
+        return string
+    }
+}

--- a/Samples/AppAmbit.App.Swift/CloudCodeView.swift
+++ b/Samples/AppAmbit.App.Swift/CloudCodeView.swift
@@ -25,15 +25,15 @@ struct CloudCodeView: View {
     private let sectionNames = ["Database", "CMS", "Push", "HTTP"]
 
     private let demos: [CloudCodeDemo] = [
-        CloudCodeDemo(id: "create-task", section: "Database", title: "Create task", slug: "cloud-demo-create-task", detail: "Insert a task for the signed-in consumer.", prerequisite: "cloud_demo_tasks", action: .createTask),
-        CloudCodeDemo(id: "list-tasks", section: "Database", title: "List tasks", slug: "cloud-demo-list-tasks", detail: "Read the current consumer's tasks.", prerequisite: "cloud_demo_tasks", action: .listTasks),
-        CloudCodeDemo(id: "complete-task", section: "Database", title: "Complete task", slug: "cloud-demo-complete-task", detail: "Update one task with consumer ownership.", prerequisite: "Task id", action: .completeTask),
-        CloudCodeDemo(id: "delete-task", section: "Database", title: "Delete task", slug: "cloud-demo-delete-task", detail: "Delete one task owned by the consumer.", prerequisite: "Task id + confirmation", action: .deleteTask),
-        CloudCodeDemo(id: "order", section: "Database", title: "Create idempotent order", slug: "cloud-demo-create-order", detail: "Create an order without duplicate idempotency keys.", prerequisite: "cloud_demo_orders", action: .createOrder),
-        CloudCodeDemo(id: "summary", section: "Database", title: "Dashboard summary", slug: "cloud-demo-dashboard-summary", detail: "Combine Database and CMS in one typed response.", prerequisite: "Database + CMS", action: .summary),
-        CloudCodeDemo(id: "create-sample-content", section: "CMS", title: "Create sample content", slug: "cloud-demo-publish-post", detail: "Create a published CMS entry.", prerequisite: "Confirmation", action: .publishPost),
-        CloudCodeDemo(id: "read-posts", section: "CMS", title: "Read CMS posts", slug: "cloud-demo-read-posts", detail: "List published entries using only CMS data.", prerequisite: "cloud_code_demo_posts", action: .readPosts),
-        CloudCodeDemo(id: "push", section: "Push", title: "Send push notification", slug: "cloud-demo-send-push", detail: "Send a notification to all consumers.", prerequisite: "Permission + APNs/FCM", action: .push),
+        CloudCodeDemo(id: "create-task", section: "Database", title: "Create task", slug: "cloud-demo-create-task-ios", detail: "Insert a task for the signed-in consumer.", prerequisite: "cloud_demo_tasks_ios", action: .createTask),
+        CloudCodeDemo(id: "list-tasks", section: "Database", title: "List tasks", slug: "cloud-demo-list-tasks-ios", detail: "Read the current consumer's tasks.", prerequisite: "cloud_demo_tasks_ios", action: .listTasks),
+        CloudCodeDemo(id: "complete-task", section: "Database", title: "Complete task", slug: "cloud-demo-complete-task-ios", detail: "Update one task with consumer ownership.", prerequisite: "Task id", action: .completeTask),
+        CloudCodeDemo(id: "delete-task", section: "Database", title: "Delete task", slug: "cloud-demo-delete-task-ios", detail: "Delete one task owned by the consumer.", prerequisite: "Task id + confirmation", action: .deleteTask),
+        CloudCodeDemo(id: "order", section: "Database", title: "Create idempotent order", slug: "cloud-demo-create-order-ios", detail: "Create an order without duplicate idempotency keys.", prerequisite: "cloud_demo_orders_ios", action: .createOrder),
+        CloudCodeDemo(id: "summary", section: "Database", title: "Dashboard summary", slug: "cloud-demo-dashboard-summary-ios", detail: "Combine Database and CMS in one typed response.", prerequisite: "Database + CMS", action: .summary),
+        CloudCodeDemo(id: "create-sample-content", section: "CMS", title: "Create sample content", slug: "cloud-demo-publish-post-ios", detail: "Create a published CMS entry.", prerequisite: "Confirmation", action: .publishPost),
+        CloudCodeDemo(id: "read-posts", section: "CMS", title: "Read CMS posts", slug: "cloud-demo-read-posts-ios", detail: "List published entries using only CMS data.", prerequisite: "cloud_code_demo_posts_ios", action: .readPosts),
+        CloudCodeDemo(id: "push", section: "Push", title: "Send push notification", slug: "cloud-demo-send-push-ios", detail: "Send a notification to all iOS consumers.", prerequisite: "Permission + APNs", action: .push),
         CloudCodeDemo(id: "inspector", section: "HTTP", title: "Inspect HTTP context", slug: "cloud-demo-http-inspector", detail: "Inspect method, query, body and consumer context.", prerequisite: "HTTP trigger", action: .inspector),
         CloudCodeDemo(id: "json-values", section: "HTTP", title: "JSON values", slug: "cloud-demo-json-values", detail: "Return common JSON value types.", prerequisite: "HTTP trigger", action: .jsonValues),
         CloudCodeDemo(id: "null-contract", section: "HTTP", title: "Null contract", slug: "cloud-demo-null-contract", detail: "Compare raw null and an explicit value.", prerequisite: "HTTP trigger", action: .nullContract),
@@ -62,7 +62,7 @@ struct CloudCodeView: View {
                                   Button {
                                       runOrConfirm(.setupDatabase, demoID: "setup-database")
                                   } label: {
-                                      Label("cloud-demo-setup-database", systemImage: "play.fill")
+                                      Label("cloud-demo-setup-database-ios", systemImage: "play.fill")
                                   }
                                  .buttonStyle(.borderedProminent)
                                  .disabled(isRunning || isVerifyingBackend)
@@ -221,7 +221,7 @@ struct CloudCodeView: View {
         databaseStatus = "Checking..."
         cmsStatus = "Checking..."
         CloudCode.call(
-            "cloud-demo-dashboard-summary",
+            "cloud-demo-dashboard-summary-ios",
             method: .get,
             query: nil,
             body: nil,
@@ -391,23 +391,23 @@ struct CloudCodeView: View {
         let taskValue = Int(taskId) ?? 0
         let headers = ["X-Sample-Client": "swift"]
         switch action {
-        case .setupDatabase: return ("cloud-demo-setup-database", .post, nil, nil, headers)
-        case .createTask: return ("cloud-demo-create-task", .post, nil, ["title": taskTitle], headers)
-        case .listTasks: return ("cloud-demo-list-tasks", .get, ["limit": "20"], nil, headers)
-        case .completeTask: return ("cloud-demo-complete-task", .patch, nil, ["task_id": taskValue], headers)
-        case .deleteTask: return ("cloud-demo-delete-task", .delete, nil, ["task_id": taskValue], headers)
+        case .setupDatabase: return ("cloud-demo-setup-database-ios", .post, nil, nil, headers)
+        case .createTask: return ("cloud-demo-create-task-ios", .post, nil, ["title": taskTitle], headers)
+        case .listTasks: return ("cloud-demo-list-tasks-ios", .get, ["limit": "20"], nil, headers)
+        case .completeTask: return ("cloud-demo-complete-task-ios", .patch, nil, ["task_id": taskValue], headers)
+        case .deleteTask: return ("cloud-demo-delete-task-ios", .delete, nil, ["task_id": taskValue], headers)
         case .inspector: return ("cloud-demo-http-inspector", .post, ["source": "swift"], ["message": "hello", "count": 2], headers)
         case .jsonValues: return ("cloud-demo-json-values", .post, nil, nil, headers)
         case .nullContract: return ("cloud-demo-null-contract", .get, nil, nil, headers)
         case .responseShapes: return ("cloud-demo-response-shapes", .post, nil, nil, headers)
         case .controlledError: return ("cloud-demo-error-response", .post, nil, ["invalid": true], headers)
         case .timeout: return ("cloud-demo-timeout-10s", .get, nil, nil, headers)
-        case .readPosts: return ("cloud-demo-read-posts", .get, postUUID.isEmpty ? nil : ["uuid": postUUID], nil, headers)
-        case .publishPost: return ("cloud-demo-publish-post", .post, nil, ["title": publishTitle, "body": publishBody], headers)
+        case .readPosts: return ("cloud-demo-read-posts-ios", .get, postUUID.isEmpty ? nil : ["uuid": postUUID], nil, headers)
+        case .publishPost: return ("cloud-demo-publish-post-ios", .post, nil, ["title": publishTitle, "body": publishBody], headers)
         case .runtimeContext: return ("cloud-demo-runtime-context", .get, nil, nil, headers)
-        case .push: return ("cloud-demo-send-push", .post, nil, ["title": "Cloud Code demo", "body": "Push from Swift sample"], headers)
-        case .createOrder: return ("cloud-demo-create-order", .post, nil, ["idempotency_key": UUID().uuidString, "amount": 100], headers)
-        case .summary: return ("cloud-demo-dashboard-summary", .get, nil, nil, headers)
+        case .push: return ("cloud-demo-send-push-ios", .post, nil, ["title": "Cloud Code iOS demo", "body": "Push from Swift sample"], headers)
+        case .createOrder: return ("cloud-demo-create-order-ios", .post, nil, ["idempotency_key": UUID().uuidString, "amount": 100], headers)
+        case .summary: return ("cloud-demo-dashboard-summary-ios", .get, nil, nil, headers)
         }
     }
 

--- a/Samples/AppAmbit.App.Swift/ContentView.swift
+++ b/Samples/AppAmbit.App.Swift/ContentView.swift
@@ -15,7 +15,8 @@ struct ContentView: View {
         AppTab(title: "Load", icon: "bolt.horizontal.circle"),
         AppTab(title: "RemoteConfig", icon: "arrow.2.circlepath.circle"),
         AppTab(title: "CMS", icon: "doc.richtext"),
-        AppTab(title: "Database", icon: "cylinder.split.1x2")
+        AppTab(title: "Database", icon: "cylinder.split.1x2"),
+        AppTab(title: "Cloud Code", icon: "cloud.bolt")
     ]
 
     var body: some View {
@@ -27,7 +28,8 @@ struct ContentView: View {
                 case 2: LoadView()
                 case 3: RemoteConfigView()
                 case 4: CmsView()
-                default: DatabaseView()
+                case 5: DatabaseView()
+                default: CloudCodeView()
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Samples/AppAmbit.App.Swift/models/CloudCodeDemo.swift
+++ b/Samples/AppAmbit.App.Swift/models/CloudCodeDemo.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+struct CloudCodeDemo: Identifiable {
+    let id: String
+    let section: String
+    let title: String
+    let slug: String
+    let detail: String
+    let prerequisite: String
+    let action: CloudCodeDemoAction?
+}
+
+enum CloudCodeDemoAction {
+    case setupDatabase
+    case createTask
+    case listTasks
+    case completeTask
+    case deleteTask
+    case inspector
+    case jsonValues
+    case nullContract
+    case responseShapes
+    case controlledError
+    case timeout
+    case readPosts
+    case publishPost
+    case runtimeContext
+    case push
+    case createOrder
+    case summary
+}

--- a/Samples/AppAmbit.App.Swift/models/DashboardSummary.swift
+++ b/Samples/AppAmbit.App.Swift/models/DashboardSummary.swift
@@ -1,0 +1,11 @@
+import AppAmbit
+
+struct DashboardSummary: Decodable {
+    let taskCount: Int?
+    let posts: [JSONValue]?
+
+    enum CodingKeys: String, CodingKey {
+        case taskCount = "task_count"
+        case posts
+    }
+}

--- a/Samples/CloudCodeExamples.js
+++ b/Samples/CloudCodeExamples.js
@@ -10,12 +10,12 @@
  * Code deploys one handler per function and each handler has its own slug.
  */
 
-// cloud-demo-setup-database | POST | Requires an existing linked Database.
+// cloud-demo-setup-database-ios | POST | Requires an existing linked Database.
 // Creates the tables used by the Database examples without destroying data.
-export const cloudDemoSetupDatabase = async (ctx) => {
+export const cloudDemoSetupDatabaseIos = async (ctx) => {
   const { results } = await ctx.appambit.batch([
     {
-      sql: `CREATE TABLE IF NOT EXISTS cloud_demo_tasks (
+      sql: `CREATE TABLE IF NOT EXISTS cloud_demo_tasks_ios (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         user_id INTEGER NOT NULL,
         title TEXT NOT NULL,
@@ -24,7 +24,7 @@ export const cloudDemoSetupDatabase = async (ctx) => {
       )`,
     },
     {
-      sql: `CREATE TABLE IF NOT EXISTS cloud_demo_orders (
+      sql: `CREATE TABLE IF NOT EXISTS cloud_demo_orders_ios (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         user_id INTEGER NOT NULL,
         idempotency_key TEXT NOT NULL,
@@ -38,137 +38,138 @@ export const cloudDemoSetupDatabase = async (ctx) => {
 
   return {
     ok: true,
-    tables: ['cloud_demo_tasks', 'cloud_demo_orders'],
+    platform: 'ios',
+    tables: ['cloud_demo_tasks_ios', 'cloud_demo_orders_ios'],
     statements: results.length,
   };
 };
 
-// cloud-demo-create-task | POST | Requires cloud_demo_tasks.
-export const cloudDemoCreateTask = async (ctx) => {
+// cloud-demo-create-task-ios | POST | Requires cloud_demo_tasks_ios.
+export const cloudDemoCreateTaskIos = async (ctx) => {
   const userId = ctx.consumer?.id;
   const title = String(ctx.req?.body?.title ?? '').trim();
   if (!userId || !title) return { status: 400, body: { error: 'title_required' } };
 
   const { results } = await ctx.appambit.db(
-    'INSERT INTO cloud_demo_tasks (user_id, title, created_at) VALUES (?, ?, ?) RETURNING *',
+    'INSERT INTO cloud_demo_tasks_ios (user_id, title, created_at) VALUES (?, ?, ?) RETURNING *',
     [userId, title, new Date().toISOString()],
   );
   const result = results[0];
   const row = result.rows[0];
   const task = Object.fromEntries(result.columns.map((column, index) => [column, row[index]]));
-  return { status: 201, body: { task } };
+  return { status: 201, body: { task, platform: 'ios' } };
 };
 
-// cloud-demo-list-tasks | GET | Requires cloud_demo_tasks.
-export const cloudDemoListTasks = async (ctx) => {
+// cloud-demo-list-tasks-ios | GET | Requires cloud_demo_tasks_ios.
+export const cloudDemoListTasksIos = async (ctx) => {
   const userId = ctx.consumer?.id;
   if (!userId) return { status: 401, body: { error: 'consumer_required' } };
 
   const requestedLimit = Number(ctx.req?.query?.limit ?? 20);
   const limit = Math.min(Math.max(Number.isFinite(requestedLimit) ? requestedLimit : 20, 1), 50);
   const { results } = await ctx.appambit.db(
-    'SELECT id, title, completed, created_at FROM cloud_demo_tasks WHERE user_id = ? ORDER BY created_at DESC LIMIT ?',
+    'SELECT id, title, completed, created_at FROM cloud_demo_tasks_ios WHERE user_id = ? ORDER BY created_at DESC LIMIT ?',
     [userId, limit],
   );
   const result = results[0];
   const tasks = result.rows.map((row) => Object.fromEntries(result.columns.map((column, index) => [column, row[index]])));
-  return { tasks };
+  return { tasks, platform: 'ios' };
 };
 
-// cloud-demo-complete-task | PATCH | Requires cloud_demo_tasks and task_id.
-export const cloudDemoCompleteTask = async (ctx) => {
+// cloud-demo-complete-task-ios | PATCH | Requires cloud_demo_tasks_ios and task_id.
+export const cloudDemoCompleteTaskIos = async (ctx) => {
   const userId = ctx.consumer?.id;
   const taskId = Number(ctx.req?.body?.task_id);
   if (!userId || !Number.isInteger(taskId) || taskId < 1) return { status: 400, body: { error: 'task_id_required' } };
 
   const { results } = await ctx.appambit.batch([
-    { sql: 'UPDATE cloud_demo_tasks SET completed = 1 WHERE id = ? AND user_id = ?', params: [taskId, userId] },
-    { sql: 'INSERT INTO cloud_demo_tasks (user_id, title, created_at) VALUES (?, ?, ?)', params: [userId, 'Transaction audit', new Date().toISOString()] },
+    { sql: 'UPDATE cloud_demo_tasks_ios SET completed = 1 WHERE id = ? AND user_id = ?', params: [taskId, userId] },
+    { sql: 'INSERT INTO cloud_demo_tasks_ios (user_id, title, created_at) VALUES (?, ?, ?)', params: [userId, 'Transaction audit iOS', new Date().toISOString()] },
   ], true);
   if ((results[1]?.rows_written ?? 0) === 0) return { status: 404, body: { error: 'task_not_found' } };
-  return { ok: true, transaction: true, statements: results.length };
+  return { ok: true, platform: 'ios', transaction: true, statements: results.length };
 };
 
-// cloud-demo-delete-task | DELETE | Requires cloud_demo_tasks, task_id and confirmation.
-export const cloudDemoDeleteTask = async (ctx) => {
+// cloud-demo-delete-task-ios | DELETE | Requires cloud_demo_tasks_ios, task_id and confirmation.
+export const cloudDemoDeleteTaskIos = async (ctx) => {
   const userId = ctx.consumer?.id;
   const taskId = Number(ctx.req?.body?.task_id);
   if (!userId || !Number.isInteger(taskId) || taskId < 1) return { status: 400, body: { error: 'task_id_required' } };
 
   const { results } = await ctx.appambit.db(
-    'DELETE FROM cloud_demo_tasks WHERE id = ? AND user_id = ?',
+    'DELETE FROM cloud_demo_tasks_ios WHERE id = ? AND user_id = ?',
     [taskId, userId],
   );
   if ((results[0]?.rows_written ?? 0) === 0) return { status: 404, body: { error: 'task_not_found' } };
   return { status: 204, body: null };
 };
 
-// cloud-demo-create-order | POST | Requires cloud_demo_orders.
-export const cloudDemoCreateOrder = async (ctx) => {
+// cloud-demo-create-order-ios | POST | Requires cloud_demo_orders_ios.
+export const cloudDemoCreateOrderIos = async (ctx) => {
   const userId = ctx.consumer?.id;
   const key = String(ctx.req?.body?.idempotency_key ?? '').trim();
   const amount = Number(ctx.req?.body?.amount);
   if (!userId || !key || !Number.isInteger(amount) || amount < 1) return { status: 400, body: { error: 'order_input_required' } };
 
   const existing = await ctx.appambit.db(
-    'SELECT id, user_id, idempotency_key, amount, status, created_at FROM cloud_demo_orders WHERE user_id = ? AND idempotency_key = ?',
+    'SELECT id, user_id, idempotency_key, amount, status, created_at FROM cloud_demo_orders_ios WHERE user_id = ? AND idempotency_key = ?',
     [userId, key],
   );
-  if (existing.results[0].rows.length > 0) return { idempotent: true, order: existing.results[0].rows[0] };
+  if (existing.results[0].rows.length > 0) return { idempotent: true, platform: 'ios', order: existing.results[0].rows[0] };
 
   try {
     const { results } = await ctx.appambit.db(
-      'INSERT INTO cloud_demo_orders (user_id, idempotency_key, amount, status, created_at) VALUES (?, ?, ?, ?, ?) RETURNING id, user_id, idempotency_key, amount, status, created_at',
+      'INSERT INTO cloud_demo_orders_ios (user_id, idempotency_key, amount, status, created_at) VALUES (?, ?, ?, ?, ?) RETURNING id, user_id, idempotency_key, amount, status, created_at',
       [userId, key, amount, 'created', new Date().toISOString()],
     );
-    return { idempotent: false, order: results[0].rows[0] };
+    return { idempotent: false, platform: 'ios', order: results[0].rows[0] };
   } catch (error) {
     return { status: 409, body: { error: 'idempotency_conflict', message: error.message } };
   }
 };
 
-// cloud-demo-dashboard-summary | GET | Requires Database and CMS setup.
-export const cloudDemoDashboardSummary = async (ctx) => {
+// cloud-demo-dashboard-summary-ios | GET | Requires Database and CMS setup.
+export const cloudDemoDashboardSummaryIos = async (ctx) => {
   const userId = ctx.consumer?.id;
   if (!userId) return { status: 401, body: { error: 'consumer_required' } };
 
   const [{ results: dbResults }, posts] = await Promise.all([
-    ctx.appambit.db('SELECT COUNT(*) AS task_count FROM cloud_demo_tasks WHERE user_id = ?', [userId]),
-    ctx.appambit.cms.list('cloud_code_demo_posts', { status: 'published', per_page: 5 }),
+    ctx.appambit.db('SELECT COUNT(*) AS task_count FROM cloud_demo_tasks_ios WHERE user_id = ?', [userId]),
+    ctx.appambit.cms.list('cloud_code_demo_posts_ios', { status: 'published', per_page: 5 }),
   ]);
-  return { task_count: dbResults[0].rows[0][0], posts: posts.data ?? [] };
+  return { task_count: dbResults[0].rows[0][0], posts: posts.data ?? [], platform: 'ios' };
 };
 
-// cloud-demo-read-posts | GET | Requires cloud_code_demo_posts.
-export const cloudDemoReadPosts = async (ctx) => {
+// cloud-demo-read-posts-ios | GET | Requires cloud_code_demo_posts_ios.
+export const cloudDemoReadPostsIos = async (ctx) => {
   const uuid = ctx.req?.query?.uuid;
-  if (uuid) return await ctx.appambit.cms.get('cloud_code_demo_posts', uuid);
-  return await ctx.appambit.cms.list('cloud_code_demo_posts', { status: 'published', per_page: 5 });
+  if (uuid) return await ctx.appambit.cms.get('cloud_code_demo_posts_ios', uuid);
+  return await ctx.appambit.cms.list('cloud_code_demo_posts_ios', { status: 'published', per_page: 5 });
 };
 
-// cloud-demo-publish-post | POST | Requires a CMS Content Type with title and body fields.
-export const cloudDemoPublishPost = async (ctx) => {
+// cloud-demo-publish-post-ios | POST | Requires cloud_code_demo_posts_ios.
+export const cloudDemoPublishPostIos = async (ctx) => {
   const title = String(ctx.req?.body?.title ?? '').trim();
   const body = String(ctx.req?.body?.body ?? '').trim();
   if (!title || !body) return { status: 400, body: { error: 'title_and_body_required' } };
 
-  const post = await ctx.appambit.cms.publish('cloud_code_demo_posts', { title, body });
-  return { status: 201, body: { post } };
+  const post = await ctx.appambit.cms.publish('cloud_code_demo_posts_ios', { title, body });
+  return { status: 201, body: { post, platform: 'ios' } };
 };
 
-// cloud-demo-send-push | POST | Requires configured APNs/FCM credentials.
-export const cloudDemoSendPush = async (ctx) => {
+// cloud-demo-send-push-ios | POST | Requires configured APNs credentials.
+export const cloudDemoSendPushIos = async (ctx) => {
   const change = ctx.event ?? {};
-  ctx.log('start new order', change);
+  ctx.log('start new iOS push', change);
 
   try {
     await ctx.appambit.push({
-      title: 'New order!',
-      body: 'You just received a new order.',
+      title: String(ctx.req?.body?.title ?? 'Cloud Code iOS demo'),
+      body: String(ctx.req?.body?.body ?? 'Push from the iOS Cloud Code function.'),
     });
 
-    ctx.log('finish new order', change);
-    return { notified: true };
+    ctx.log('finish iOS push', change);
+    return { notified: true, platform: 'ios' };
   } catch (error) {
     const errorDetails = error instanceof Error
       ? { name: error.name, message: error.message, stack: error.stack ?? null }
@@ -176,6 +177,150 @@ export const cloudDemoSendPush = async (ctx) => {
     ctx.log('push failed', { change, error: errorDetails });
     throw error;
   }
+};
+
+// cloud-demo-setup-database-android | POST | Requires an existing linked Database.
+export const cloudDemoSetupDatabaseAndroid = async (ctx) => {
+  const { results } = await ctx.appambit.batch([
+    {
+      sql: `CREATE TABLE IF NOT EXISTS cloud_demo_tasks_android (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        title TEXT NOT NULL,
+        completed INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL
+      )`,
+    },
+    {
+      sql: `CREATE TABLE IF NOT EXISTS cloud_demo_orders_android (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        idempotency_key TEXT NOT NULL,
+        amount INTEGER NOT NULL,
+        status TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE (user_id, idempotency_key)
+      )`,
+    },
+  ], true);
+  return { ok: true, platform: 'android', tables: ['cloud_demo_tasks_android', 'cloud_demo_orders_android'], statements: results.length };
+};
+
+// cloud-demo-create-task-android | POST | Requires cloud_demo_tasks_android.
+export const cloudDemoCreateTaskAndroid = async (ctx) => {
+  const userId = ctx.consumer?.id;
+  const title = String(ctx.req?.body?.title ?? '').trim();
+  if (!userId || !title) return { status: 400, body: { error: 'title_required' } };
+  const { results } = await ctx.appambit.db('INSERT INTO cloud_demo_tasks_android (user_id, title, created_at) VALUES (?, ?, ?) RETURNING *', [userId, title, new Date().toISOString()]);
+  const result = results[0];
+  const row = result.rows[0];
+  const task = Object.fromEntries(result.columns.map((column, index) => [column, row[index]]));
+  return { status: 201, body: { task, platform: 'android' } };
+};
+
+// cloud-demo-list-tasks-android | GET | Requires cloud_demo_tasks_android.
+export const cloudDemoListTasksAndroid = async (ctx) => {
+  const userId = ctx.consumer?.id;
+  if (!userId) return { status: 401, body: { error: 'consumer_required' } };
+  const requestedLimit = Number(ctx.req?.query?.limit ?? 20);
+  const limit = Math.min(Math.max(Number.isFinite(requestedLimit) ? requestedLimit : 20, 1), 50);
+  const { results } = await ctx.appambit.db('SELECT id, title, completed, created_at FROM cloud_demo_tasks_android WHERE user_id = ? ORDER BY created_at DESC LIMIT ?', [userId, limit]);
+  const result = results[0];
+  const tasks = result.rows.map((row) => Object.fromEntries(result.columns.map((column, index) => [column, row[index]])));
+  return { tasks, platform: 'android' };
+};
+
+// cloud-demo-complete-task-android | PATCH | Requires cloud_demo_tasks_android and task_id.
+export const cloudDemoCompleteTaskAndroid = async (ctx) => {
+  const userId = ctx.consumer?.id;
+  const taskId = Number(ctx.req?.body?.task_id);
+  if (!userId || !Number.isInteger(taskId) || taskId < 1) return { status: 400, body: { error: 'task_id_required' } };
+  const { results } = await ctx.appambit.batch([
+    { sql: 'UPDATE cloud_demo_tasks_android SET completed = 1 WHERE id = ? AND user_id = ?', params: [taskId, userId] },
+    { sql: 'INSERT INTO cloud_demo_tasks_android (user_id, title, created_at) VALUES (?, ?, ?)', params: [userId, 'Transaction audit Android', new Date().toISOString()] },
+  ], true);
+  if ((results[1]?.rows_written ?? 0) === 0) return { status: 404, body: { error: 'task_not_found' } };
+  return { ok: true, platform: 'android', transaction: true, statements: results.length };
+};
+
+// cloud-demo-delete-task-android | DELETE | Requires cloud_demo_tasks_android, task_id and confirmation.
+export const cloudDemoDeleteTaskAndroid = async (ctx) => {
+  const userId = ctx.consumer?.id;
+  const taskId = Number(ctx.req?.body?.task_id);
+  if (!userId || !Number.isInteger(taskId) || taskId < 1) return { status: 400, body: { error: 'task_id_required' } };
+  const result = await ctx.appambit.db('DELETE FROM cloud_demo_tasks_android WHERE id = ? AND user_id = ?', [taskId, userId]);
+  if ((result.results[0]?.rows_written ?? 0) === 0) return { status: 404, body: { error: 'task_not_found' } };
+  return { status: 204, body: null };
+};
+
+// cloud-demo-create-order-android | POST | Requires cloud_demo_orders_android.
+export const cloudDemoCreateOrderAndroid = async (ctx) => {
+  const userId = ctx.consumer?.id;
+  const key = String(ctx.req?.body?.idempotency_key ?? '').trim();
+  const amount = Number(ctx.req?.body?.amount);
+  if (!userId || !key || !Number.isInteger(amount) || amount < 1) return { status: 400, body: { error: 'order_input_required' } };
+  const existing = await ctx.appambit.db('SELECT id, user_id, idempotency_key, amount, status, created_at FROM cloud_demo_orders_android WHERE user_id = ? AND idempotency_key = ?', [userId, key]);
+  if (existing.results[0].rows.length > 0) return { idempotent: true, platform: 'android', order: existing.results[0].rows[0] };
+  try {
+    const { results } = await ctx.appambit.db('INSERT INTO cloud_demo_orders_android (user_id, idempotency_key, amount, status, created_at) VALUES (?, ?, ?, ?, ?) RETURNING id, user_id, idempotency_key, amount, status, created_at', [userId, key, amount, 'created', new Date().toISOString()]);
+    return { idempotent: false, platform: 'android', order: results[0].rows[0] };
+  } catch (error) {
+    return { status: 409, body: { error: 'idempotency_conflict', message: error.message } };
+  }
+};
+
+// cloud-demo-dashboard-summary-android | GET | Requires Database and CMS setup.
+export const cloudDemoDashboardSummaryAndroid = async (ctx) => {
+  const userId = ctx.consumer?.id;
+  if (!userId) return { status: 401, body: { error: 'consumer_required' } };
+  const [{ results: dbResults }, posts] = await Promise.all([
+    ctx.appambit.db('SELECT COUNT(*) AS task_count FROM cloud_demo_tasks_android WHERE user_id = ?', [userId]),
+    ctx.appambit.cms.list('cloud_code_demo_posts_android', { status: 'published', per_page: 5 }),
+  ]);
+  return { task_count: dbResults[0].rows[0][0], posts: posts.data ?? [], platform: 'android' };
+};
+
+// cloud-demo-read-posts-android | GET | Requires cloud_code_demo_posts_android.
+export const cloudDemoReadPostsAndroid = async (ctx) => {
+  const uuid = ctx.req?.query?.uuid;
+  if (uuid) return await ctx.appambit.cms.get('cloud_code_demo_posts_android', uuid);
+  return await ctx.appambit.cms.list('cloud_code_demo_posts_android', { status: 'published', per_page: 5 });
+};
+
+// cloud-demo-publish-post-android | POST | Requires cloud_code_demo_posts_android.
+export const cloudDemoPublishPostAndroid = async (ctx) => {
+  const title = String(ctx.req?.body?.title ?? '').trim();
+  const body = String(ctx.req?.body?.body ?? '').trim();
+  if (!title || !body) return { status: 400, body: { error: 'title_and_body_required' } };
+  const post = await ctx.appambit.cms.publish('cloud_code_demo_posts_android', { title, body });
+  return { status: 201, body: { post, platform: 'android' } };
+};
+
+// cloud-demo-send-push-android | POST | Requires configured FCM credentials.
+export const cloudDemoSendPushAndroid = async (ctx) => {
+  const change = ctx.event ?? {};
+  ctx.log('start new Android push', change);
+  try {
+    await ctx.appambit.push({
+      title: String(ctx.req?.body?.title ?? 'Cloud Code Android demo'),
+      body: String(ctx.req?.body?.body ?? 'Push from the Android Cloud Code function.'),
+    });
+    ctx.log('finish Android push', change);
+    return { notified: true, platform: 'android' };
+  } catch (error) {
+    const errorDetails = error instanceof Error
+      ? { name: error.name, message: error.message, stack: error.stack ?? null }
+      : { value: String(error) };
+    ctx.log('push failed', { change, error: errorDetails });
+    throw error;
+  }
+};
+
+// cloud-demo-task-event-android | Event trigger | Runs after cloud_demo_tasks_android changes.
+export const cloudDemoTaskEventAndroid = async (ctx) => {
+  const change = ctx.event ?? {};
+  ctx.log('cloud_demo_tasks_android changed', { operation: change.operation, table: change.table });
+  return { handled: true, platform: 'android', operation: change.operation ?? null };
 };
 
 // cloud-demo-http-inspector | POST | Requires an HTTP trigger.
@@ -231,11 +376,11 @@ export const cloudDemoRuntimeContext = async (ctx) => {
   return { region, has_secret: hasSecret };
 };
 
-// cloud-demo-task-event | Event trigger | Runs after cloud_demo_tasks changes.
-export const cloudDemoTaskEvent = async (ctx) => {
+// cloud-demo-task-event-ios | Event trigger | Runs after cloud_demo_tasks_ios changes.
+export const cloudDemoTaskEventIos = async (ctx) => {
   const change = ctx.event ?? {};
-  ctx.log('cloud_demo_tasks changed', { operation: change.operation, table: change.table });
-  return { handled: true, operation: change.operation ?? null };
+  ctx.log('cloud_demo_tasks_ios changed', { operation: change.operation, table: change.table });
+  return { handled: true, platform: 'ios', operation: change.operation ?? null };
 };
 
 // cloud-demo-manual-report | Manual trigger | Runs from the Dashboard.

--- a/Samples/CloudCodeExamples.js
+++ b/Samples/CloudCodeExamples.js
@@ -1,0 +1,246 @@
+/*
+ * AppAmbit Cloud Code examples catalog.
+ *
+ * Each function below is a deployable handler body. To deploy one example,
+ * copy its function body to index.js and export it as `handler`:
+ *
+ * export const handler = async (ctx) => { ... };
+ *
+ * The catalog is intentionally not deployed as one function because Cloud
+ * Code deploys one handler per function and each handler has its own slug.
+ */
+
+// cloud-demo-setup-database | POST | Requires an existing linked Database.
+// Creates the tables used by the Database examples without destroying data.
+export const cloudDemoSetupDatabase = async (ctx) => {
+  const { results } = await ctx.appambit.batch([
+    {
+      sql: `CREATE TABLE IF NOT EXISTS cloud_demo_tasks (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        title TEXT NOT NULL,
+        completed INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL
+      )`,
+    },
+    {
+      sql: `CREATE TABLE IF NOT EXISTS cloud_demo_orders (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        user_id INTEGER NOT NULL,
+        idempotency_key TEXT NOT NULL,
+        amount INTEGER NOT NULL,
+        status TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        UNIQUE (user_id, idempotency_key)
+      )`,
+    },
+  ], true);
+
+  return {
+    ok: true,
+    tables: ['cloud_demo_tasks', 'cloud_demo_orders'],
+    statements: results.length,
+  };
+};
+
+// cloud-demo-create-task | POST | Requires cloud_demo_tasks.
+export const cloudDemoCreateTask = async (ctx) => {
+  const userId = ctx.consumer?.id;
+  const title = String(ctx.req?.body?.title ?? '').trim();
+  if (!userId || !title) return { status: 400, body: { error: 'title_required' } };
+
+  const { results } = await ctx.appambit.db(
+    'INSERT INTO cloud_demo_tasks (user_id, title, created_at) VALUES (?, ?, ?) RETURNING *',
+    [userId, title, new Date().toISOString()],
+  );
+  const result = results[0];
+  const row = result.rows[0];
+  const task = Object.fromEntries(result.columns.map((column, index) => [column, row[index]]));
+  return { status: 201, body: { task } };
+};
+
+// cloud-demo-list-tasks | GET | Requires cloud_demo_tasks.
+export const cloudDemoListTasks = async (ctx) => {
+  const userId = ctx.consumer?.id;
+  if (!userId) return { status: 401, body: { error: 'consumer_required' } };
+
+  const requestedLimit = Number(ctx.req?.query?.limit ?? 20);
+  const limit = Math.min(Math.max(Number.isFinite(requestedLimit) ? requestedLimit : 20, 1), 50);
+  const { results } = await ctx.appambit.db(
+    'SELECT id, title, completed, created_at FROM cloud_demo_tasks WHERE user_id = ? ORDER BY created_at DESC LIMIT ?',
+    [userId, limit],
+  );
+  const result = results[0];
+  const tasks = result.rows.map((row) => Object.fromEntries(result.columns.map((column, index) => [column, row[index]])));
+  return { tasks };
+};
+
+// cloud-demo-complete-task | PATCH | Requires cloud_demo_tasks and task_id.
+export const cloudDemoCompleteTask = async (ctx) => {
+  const userId = ctx.consumer?.id;
+  const taskId = Number(ctx.req?.body?.task_id);
+  if (!userId || !Number.isInteger(taskId) || taskId < 1) return { status: 400, body: { error: 'task_id_required' } };
+
+  const { results } = await ctx.appambit.batch([
+    { sql: 'UPDATE cloud_demo_tasks SET completed = 1 WHERE id = ? AND user_id = ?', params: [taskId, userId] },
+    { sql: 'INSERT INTO cloud_demo_tasks (user_id, title, created_at) VALUES (?, ?, ?)', params: [userId, 'Transaction audit', new Date().toISOString()] },
+  ], true);
+  if ((results[1]?.rows_written ?? 0) === 0) return { status: 404, body: { error: 'task_not_found' } };
+  return { ok: true, transaction: true, statements: results.length };
+};
+
+// cloud-demo-delete-task | DELETE | Requires cloud_demo_tasks, task_id and confirmation.
+export const cloudDemoDeleteTask = async (ctx) => {
+  const userId = ctx.consumer?.id;
+  const taskId = Number(ctx.req?.body?.task_id);
+  if (!userId || !Number.isInteger(taskId) || taskId < 1) return { status: 400, body: { error: 'task_id_required' } };
+
+  const { results } = await ctx.appambit.db(
+    'DELETE FROM cloud_demo_tasks WHERE id = ? AND user_id = ?',
+    [taskId, userId],
+  );
+  if ((results[0]?.rows_written ?? 0) === 0) return { status: 404, body: { error: 'task_not_found' } };
+  return { status: 204, body: null };
+};
+
+// cloud-demo-create-order | POST | Requires cloud_demo_orders.
+export const cloudDemoCreateOrder = async (ctx) => {
+  const userId = ctx.consumer?.id;
+  const key = String(ctx.req?.body?.idempotency_key ?? '').trim();
+  const amount = Number(ctx.req?.body?.amount);
+  if (!userId || !key || !Number.isInteger(amount) || amount < 1) return { status: 400, body: { error: 'order_input_required' } };
+
+  const existing = await ctx.appambit.db(
+    'SELECT id, user_id, idempotency_key, amount, status, created_at FROM cloud_demo_orders WHERE user_id = ? AND idempotency_key = ?',
+    [userId, key],
+  );
+  if (existing.results[0].rows.length > 0) return { idempotent: true, order: existing.results[0].rows[0] };
+
+  try {
+    const { results } = await ctx.appambit.db(
+      'INSERT INTO cloud_demo_orders (user_id, idempotency_key, amount, status, created_at) VALUES (?, ?, ?, ?, ?) RETURNING id, user_id, idempotency_key, amount, status, created_at',
+      [userId, key, amount, 'created', new Date().toISOString()],
+    );
+    return { idempotent: false, order: results[0].rows[0] };
+  } catch (error) {
+    return { status: 409, body: { error: 'idempotency_conflict', message: error.message } };
+  }
+};
+
+// cloud-demo-dashboard-summary | GET | Requires Database and CMS setup.
+export const cloudDemoDashboardSummary = async (ctx) => {
+  const userId = ctx.consumer?.id;
+  if (!userId) return { status: 401, body: { error: 'consumer_required' } };
+
+  const [{ results: dbResults }, posts] = await Promise.all([
+    ctx.appambit.db('SELECT COUNT(*) AS task_count FROM cloud_demo_tasks WHERE user_id = ?', [userId]),
+    ctx.appambit.cms.list('cloud_code_demo_posts', { status: 'published', per_page: 5 }),
+  ]);
+  return { task_count: dbResults[0].rows[0][0], posts: posts.data ?? [] };
+};
+
+// cloud-demo-read-posts | GET | Requires cloud_code_demo_posts.
+export const cloudDemoReadPosts = async (ctx) => {
+  const uuid = ctx.req?.query?.uuid;
+  if (uuid) return await ctx.appambit.cms.get('cloud_code_demo_posts', uuid);
+  return await ctx.appambit.cms.list('cloud_code_demo_posts', { status: 'published', per_page: 5 });
+};
+
+// cloud-demo-publish-post | POST | Requires a CMS Content Type with title and body fields.
+export const cloudDemoPublishPost = async (ctx) => {
+  const title = String(ctx.req?.body?.title ?? '').trim();
+  const body = String(ctx.req?.body?.body ?? '').trim();
+  if (!title || !body) return { status: 400, body: { error: 'title_and_body_required' } };
+
+  const post = await ctx.appambit.cms.publish('cloud_code_demo_posts', { title, body });
+  return { status: 201, body: { post } };
+};
+
+// cloud-demo-send-push | POST | Requires configured APNs/FCM credentials.
+export const cloudDemoSendPush = async (ctx) => {
+  const change = ctx.event ?? {};
+  ctx.log('start new order', change);
+
+  try {
+    await ctx.appambit.push({
+      title: 'New order!',
+      body: 'You just received a new order.',
+    });
+
+    ctx.log('finish new order', change);
+    return { notified: true };
+  } catch (error) {
+    const errorDetails = error instanceof Error
+      ? { name: error.name, message: error.message, stack: error.stack ?? null }
+      : { value: String(error) };
+    ctx.log('push failed', { change, error: errorDetails });
+    throw error;
+  }
+};
+
+// cloud-demo-http-inspector | POST | Requires an HTTP trigger.
+export const cloudDemoHttpInspector = async (ctx) => ({
+  context: {
+    method: ctx.req?.method ?? null,
+    slug: ctx.req?.slug ?? null,
+    query: ctx.req?.query ?? {},
+    headers: ctx.req?.headers ?? {},
+    body: ctx.req?.body ?? {},
+    consumer_id: ctx.consumer?.id ?? null,
+  },
+});
+
+// cloud-demo-json-values | POST | Requires an HTTP trigger.
+export const cloudDemoJsonValues = async () => ({
+  object: { ok: true },
+  array: [1, 'two', true],
+  string: 'hello',
+  number: 7,
+  boolean: true,
+});
+
+// cloud-demo-null-contract | GET | Requires an HTTP trigger.
+export const cloudDemoNullContract = async () => ({
+  raw: null,
+  explicit: { value: null },
+});
+
+// cloud-demo-response-shapes | POST | Requires an HTTP trigger.
+export const cloudDemoResponseShapes = async (ctx) => {
+  if (ctx.req?.query?.empty === 'true') return { status: 204, body: null };
+  return { status: 201, headers: { 'X-Custom': 'yes' }, body: { created: true, status_example: 201 } };
+};
+
+// cloud-demo-error-response | POST | Requires an HTTP trigger.
+export const cloudDemoErrorResponse = async (ctx) => {
+  if (!ctx.req?.body?.valid) return { status: 400, body: { error: 'validation_failed', message: 'Set valid=true to pass validation.' } };
+  return { ok: true };
+};
+
+// cloud-demo-timeout-10s | GET | Requires a 10 second function timeout.
+export const cloudDemoTimeout = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 12000));
+  return { completed_after_seconds: 12 };
+};
+
+// cloud-demo-runtime-context | GET | Requires DEMO_REGION and DEMO_SECRET configuration.
+export const cloudDemoRuntimeContext = async (ctx) => {
+  const region = ctx.env?.DEMO_REGION ?? null;
+  const hasSecret = Boolean(ctx.secrets?.DEMO_SECRET);
+  ctx.log('Cloud Code context demo', { has_region: Boolean(region), has_secret: hasSecret });
+  return { region, has_secret: hasSecret };
+};
+
+// cloud-demo-task-event | Event trigger | Runs after cloud_demo_tasks changes.
+export const cloudDemoTaskEvent = async (ctx) => {
+  const change = ctx.event ?? {};
+  ctx.log('cloud_demo_tasks changed', { operation: change.operation, table: change.table });
+  return { handled: true, operation: change.operation ?? null };
+};
+
+// cloud-demo-manual-report | Manual trigger | Runs from the Dashboard.
+export const cloudDemoManualReport = async (ctx) => {
+  const input = ctx.req ?? {};
+  ctx.log('manual demo run', input);
+  return { ran: true, input };
+};


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🛠️ Refactor
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Optimization
- [x] 📚 Documentation Update

## Description

Adds Cloud Code HTTP invocation support to the iOS SDK for Swift and Objective-C.

- Adds dynamic and typed JSON responses.
- Reuses the authenticated consumer token and retries once after `401` token renewal.
- Preserves HTTP status codes, response bodies, and request IDs.
- Adds request cancellation and Cloud Code-specific timeout handling.
- Updates Swift and Objective-C sample apps with Database, CMS, Push, and HTTP examples.
- Updates release documentation for core SDK version `1.2.0`.

## Related Tickets & Documents

- [ID-1768](https://app.asana.com/1/1203353714760101/project/1204450899416459/task/1214202178827223?focus=true)
- Closes #ID-1768

## QA Instructions, Screenshots, Recordings

1. Use the AppAmbit MCP with the test app `iOS Swift(Objc)` from the AppAmbit test account.
2. Use the existing linked Database `DBV2` and verify the `cloud_demo_tasks_ios` and `cloud_demo_orders_ios` tables.
3. Use the existing CMS content type `Cloud Code Demo Posts iOS` (`cloud_code_demo_posts_ios`), with `title` and `body` fields and at least one published entry.
4. Use the AppAmbit MCP with app key `e6174d4c-298b-4221-9a2d-1e913b912e25`. Read `Samples/CloudCodeExamples.js` as the source of truth and use the iOS handlers in that file to create, deploy, activate, and configure every iOS Cloud Code example function. Use each handler's slug and trigger requirements from the comments in that file.
5. Set the test app key in the Swift or Objective-C sample app and open the **Cloud Code** tab.
6. Run the Database setup function from `Samples/CloudCodeExamples.js` first, then test the Database, CMS, Push, event, manual, and HTTP contract examples from that catalog.
7. Verify that successful responses show the HTTP status, body, duration, and request ID. Also test the controlled error, cancellation, and missing-token refresh paths.

Validation commands:

```bash
pod lib lint AppAmbitSdk/AppAmbitSdk.podspec --platforms=ios --fail-fast --allow-warnings
xcodebuild build -workspace AppAmbit.xcodeproj/project.xcworkspace -scheme AppAmbit.App.Swift -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1' CODE_SIGNING_ALLOWED=NO
xcodebuild build -workspace AppAmbit.xcodeproj/project.xcworkspace -scheme AppAmbit.App.ObjC -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1' CODE_SIGNING_ALLOWED=NO
git diff --check
```

No UI screenshots or recordings are required.

## Added/updated tests?

- [x] ✅ Yes
- [ ] ❌ No, and this is why:
- [ ] 🤔 I need help with writing tests

## Are there any post deployment tasks we need to perform?

- [x] 📝 Yes (please add details)
- [ ] ❌ No
- [ ] ❓ I don't know

After deployment, publish the core SDK and confirm that the documentation uses `1.2.0`. The CocoaPods Push products remain at `1.1.2` because this PR does not change Push code.

## [optional] What gif best describes this PR or how it makes you feel?

![Cloud Code](https://media.giphy.com/media/xNBcChLQt7s9a/giphy.gif?cid=790b76110nm03zf29woxqwx7euymmffakb8valf74ione1sn&ep=v1_gifs_search&rid=giphy.gif&ct=v1)
